### PR TITLE
fixed incorrect keyword in middleware causing crash

### DIFF
--- a/src/source/middleware/core.clj
+++ b/src/source/middleware/core.clj
@@ -11,7 +11,7 @@
 (defn apply-generic [app]
   (-> app
       (content-type/wrap-content-type)
-      (wrap-cors :access-control-allow-origin [(re-pattern (conf/read-value :origin))]
+      (wrap-cors :access-control-allow-origin [(re-pattern (conf/read-value :cors-origin))]
                  :access-control-allow-methods [:get :put :post :delete])
       (wrap-params)
       (wrap-defaults (assoc site-defaults :session false :security {:anti-forgery false}))


### PR DESCRIPTION
fixed a nightmare inducing bug that caused the server not to start. this was fixed by changing :origin to :cors-origin.
