### PR TITLE
add routes to reitit router

### DIFF
--- a/src/source/routes/add_admin.clj
+++ b/src/source/routes/add_admin.clj
@@ -1,0 +1,19 @@
+(ns source.routes.add-admin
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn handler [{:keys [ds body] :as _request}]
+  ;;TODO: needs schema validation here
+  (let [{:keys [email password confirm-password]} body
+        existing-user (services/user ds {:where [:= :email email]})]
+    (cond
+      (not (= password confirm-password))
+      (-> (res/response {:error "passwords do not match"})
+          (res/status 401))
+
+      (some? existing-user)
+      (-> (res/response {:error "an account for this email already exists!"}))
+
+      :else
+      (-> (services/register ds (merge body {:type "admin"}))
+          (res/response)))))

--- a/src/source/routes/admin.clj
+++ b/src/source/routes/admin.clj
@@ -3,13 +3,13 @@
             [source.db.util :as db.util]
             [source.password :as pw]))
 
-(defn add-admin [req]
+(defn post [request]
   (let [ds (db.util/conn :master)
         user (db.users/user-by
               ds
               {:col "email"
-               :val (get-in req [:body :email])})
-        {:keys [password confirm-password]} (:body req)]
+               :val (get-in request [:body :email])})
+        {:keys [password confirm-password]} (:body request)]
     (cond
       (not (= password confirm-password))
       {:status 400 :body {:message "passwords do not match!"}}
@@ -18,7 +18,7 @@
       {:status 400 :body {:message "an account for this email already exists!"}}
 
       :else
-      (let [new-user (get-in req [:body])]
+      (let [new-user (get-in request [:body])]
         (db.users/insert-user ds {:email (:email new-user)
                                   :password (pw/hash-password password)
                                   :firstname (:firstname new-user)

--- a/src/source/routes/authorized.clj
+++ b/src/source/routes/authorized.clj
@@ -1,0 +1,6 @@
+(ns source.routes.authorized)
+
+(defn handler [req]
+  {:status 200
+   :body (:user req)})
+

--- a/src/source/routes/authorized.clj
+++ b/src/source/routes/authorized.clj
@@ -1,6 +1,6 @@
 (ns source.routes.authorized)
 
-(defn handler [req]
+(defn get [{:keys [user]} :as _request]
   {:status 200
-   :body (:user req)})
+   :body {:user user}})
 

--- a/src/source/routes/interface.clj
+++ b/src/source/routes/interface.clj
@@ -1,28 +1,6 @@
 (ns source.routes.interface
-  (:require [source.routes.user :as user]
-            [source.routes.users :as users]
-            [source.routes.login :as login]
-            [source.routes.authorized :as authorized]
-            [source.routes.register :as register]
-            [source.routes.add-admin :as add-admin]))
+  (:require [source.routes.reitit :as reitit]))
 
-(defn users [request]
-  (users/handler request))
+(defn create-app []
+  (reitit/create-app))
 
-(defn user [request]
-  (user/get-handler request))
-
-(defn update-user [request]
-  (user/patch-handler request))
-
-(defn login [request]
-  (login/handler request))
-
-(defn register [request]
-  (register/handler request))
-
-(defn authorized [request]
-  (authorized/handler request))
-
-(defn add-admin [request]
-  (add-admin/handler request))

--- a/src/source/routes/interface.clj
+++ b/src/source/routes/interface.clj
@@ -1,6 +1,6 @@
 (ns source.routes.interface
-  (:require [source.routes.users :as users]
-            [source.routes.user :as user]
+  (:require [source.routes.user :as user]
+            [source.routes.users :as users]
             [source.routes.login :as login]
             [source.routes.register :as register]))
 
@@ -8,10 +8,13 @@
   (users/handler request))
 
 (defn user [request]
-  (users/handler request))
+  (user/get-handler request))
+
+(defn update-user [request]
+  (user/patch-handler request))
 
 (defn login [request]
   (login/handler request))
 
-(defn registe [request]
+(defn register [request]
   (register/handler request))

--- a/src/source/routes/interface.clj
+++ b/src/source/routes/interface.clj
@@ -2,7 +2,9 @@
   (:require [source.routes.user :as user]
             [source.routes.users :as users]
             [source.routes.login :as login]
-            [source.routes.register :as register]))
+            [source.routes.authorized :as authorized]
+            [source.routes.register :as register]
+            [source.routes.add-admin :as add-admin]))
 
 (defn users [request]
   (users/handler request))
@@ -18,3 +20,9 @@
 
 (defn register [request]
   (register/handler request))
+
+(defn authorized [request]
+  (authorized/handler request))
+
+(defn add-admin [request]
+  (add-admin/handler request))

--- a/src/source/routes/login.clj
+++ b/src/source/routes/login.clj
@@ -7,9 +7,14 @@
 (defn handler [{:keys [ds body] :as _request}]
   (let [{:keys [email password]} body
         user (users/user ds {:where [:= :email email]})]
-    (cond
+    (if
       (or (not (pw/verify-password password (:password user)))
           (not (some? user)))
       {:status 401 :body {:message "Invalid username or password!"}}
 
-      :else (res/response (auth/login ds user)))))
+      (res/response (auth/login ds {:user user})))))
+
+(comment 
+  (require '[source.db.interface :as db])
+  (handler {:ds (db/ds :master) :body {:email "toast@toast.com" :password "poop"}})
+  ())

--- a/src/source/routes/login.clj
+++ b/src/source/routes/login.clj
@@ -4,17 +4,17 @@
             [source.services.users :as users]
             [source.password :as pw]))
 
-(defn handler [{:keys [ds body] :as _request}]
+(defn post [{:keys [ds body] :as _request}]
   (let [{:keys [email password]} body
         user (users/user ds {:where [:= :email email]})]
     (if
-      (or (not (pw/verify-password password (:password user)))
-          (not (some? user)))
+     (or (not (pw/verify-password password (:password user)))
+         (not (some? user)))
       {:status 401 :body {:message "Invalid username or password!"}}
 
       (res/response (auth/login ds {:user user})))))
 
-(comment 
+(comment
   (require '[source.db.interface :as db])
-  (handler {:ds (db/ds :master) :body {:email "toast@toast.com" :password "poop"}})
+  (post {:ds (db/ds :master) :body {:email "toast@toast.com" :password "poop"}})
   ())

--- a/src/source/routes/protected.clj
+++ b/src/source/routes/protected.clj
@@ -1,6 +1,0 @@
-(ns source.routes.protected)
-
-(defn authorized [req]
-  {:status 200
-   :body (:user req)})
-

--- a/src/source/routes/register.clj
+++ b/src/source/routes/register.clj
@@ -2,7 +2,7 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn handler [{:keys [ds body] :as _request}]
+(defn post [{:keys [ds body] :as _request}]
   ;;TODO: needs schema validation here
   (let [{:keys [email password confirm-password]} body
         existing-user (services/user ds {:where [:= :email email]})]
@@ -18,10 +18,10 @@
       (-> (services/register ds body)
           (res/response)))))
 
-(comment 
+(comment
   (require '[source.db.interface :as db])
-  (handler {:ds (db/ds :master) :body {:email "test@test.com" 
-                                       :password "test"
-                                       :type "distributor"
-                                       :confirm-password "test"}})
+  (post {:ds (db/ds :master) :body {:email "test@test.com"
+                                    :password "test"
+                                    :type "distributor"
+                                    :confirm-password "test"}})
   ())

--- a/src/source/routes/register.clj
+++ b/src/source/routes/register.clj
@@ -2,9 +2,9 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn handler [{:keys [ds user] :as _Request}]
-  ;;todo: needs scehma validation here
-  (let [{:keys [email password confirm-password]} user
+(defn handler [{:keys [ds body] :as _request}]
+  ;;TODO: needs schema validation here
+  (let [{:keys [email password confirm-password]} body
         existing-user (services/user ds {:where [:= :email email]})]
     (cond
       (not (= password confirm-password))
@@ -15,5 +15,13 @@
       (-> (res/response {:error "an account for this email already exists!"}))
 
       :else
-      (-> (services/register ds user)
+      (-> (services/register ds body)
           (res/response)))))
+
+(comment 
+  (require '[source.db.interface :as db])
+  (handler {:ds (db/ds :master) :body {:email "test@test.com" 
+                                       :password "test"
+                                       :type "distributor"
+                                       :confirm-password "test"}})
+  ())

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -11,14 +11,19 @@
      (ring/router
       [["/" {:middleware [[mw/apply-generic :ds ds]]}
         ["" (fn [_request] {:status 200 :body {:message "success"}})]
-        ["users" 
+        ["users"
          ["" routes/users]
          ["/:id" {:get routes/user
                   :patch routes/update-user}]]
-        ["login" routes/login]
-        ["register" routes/register]]]))))
+        ["login" {:post routes/login}]
+        ["register" routes/register]
+        ["protected" {:middleware [[mw/apply-auth]]}
+         ["/authorized" routes/authorized]]
+        ["admin" {:middleware [[mw/apply-auth {:required-type :admin}]]}
+         ["/add-admin" {:post routes/add-admin}]]]]))))
 
 (comment
+  (require '[source.middleware.auth.util :as auth.util])
 
   (let [app (create-app)
         request {:uri "/users" :request-method :get}]
@@ -35,12 +40,34 @@
         (json/read-json {:key-fn keyword})))
 
   (let [app (create-app)
-        request {:uri "/users/5" 
+        request {:uri "/users/5"
                  :request-method :patch
-                 :body {:firstname "kiigan" 
+                 :body {:firstname "kiigan"
                         :lastname "korinzu"}}]
     (-> request
         app
-        :body 
+        :body
         (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/protected/authorized"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 5 :type "distributor"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/admin/add-admin"
+                 :request-method :post
+                 :body {:email "test@test.com"
+                        :password "test"
+                        :confirm-password "test"}
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
   ())

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -3,7 +3,12 @@
             [source.middleware.interface :as mw]
             [source.db.interface :as db]
             [clojure.data.json :as json]
-            [source.routes.interface :as routes]))
+            [source.routes.user :as user]
+            [source.routes.users :as users]
+            [source.routes.login :as login]
+            [source.routes.register :as register]
+            [source.routes.admin :as admin]
+            [source.routes.authorized :as authorized]))
 
 (defn create-app []
   (let [ds (db/ds :master)]
@@ -12,15 +17,15 @@
       [["/" {:middleware [[mw/apply-generic :ds ds]]}
         ["" (fn [_request] {:status 200 :body {:message "success"}})]
         ["users"
-         ["" routes/users]
-         ["/:id" {:get routes/user
-                  :patch routes/update-user}]]
-        ["login" {:post routes/login}]
-        ["register" routes/register]
+         ["" users/handler]
+         ["/:id" {:get user/get
+                  :patch user/patch}]]
+        ["login" {:post login/post}]
+        ["register" {:post register/post}]
         ["protected" {:middleware [[mw/apply-auth]]}
-         ["/authorized" routes/authorized]]
+         ["/authorized" {:get authorized/get}]]
         ["admin" {:middleware [[mw/apply-auth {:required-type :admin}]]}
-         ["/add-admin" {:post routes/add-admin}]]]]))))
+         ["/add-admin" {:post admin/post}]]]]))))
 
 (comment
   (require '[source.middleware.auth.util :as auth.util])
@@ -33,7 +38,7 @@
         (json/read-json {:key-fn keyword})))
 
   (let [app (create-app)
-        request {:uri "/users/2" :request-method :get}]
+        request {:uri "/users/5" :request-method :get}]
     (-> request
         app
         :body

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -10,9 +10,11 @@
     (ring/ring-handler
      (ring/router
       [["/" {:middleware [[mw/apply-generic :ds ds]]}
-        ["" (fn [request] {:status 200 :body {:message "success"}})]
-        ["users" routes/users]
-        ["user" routes/user]
+        ["" (fn [_request] {:status 200 :body {:message "success"}})]
+        ["users" 
+         ["" routes/users]
+         ["/:id" {:get routes/user
+                  :patch routes/update-user}]]
         ["login" routes/login]
         ["register" routes/register]]]))))
 
@@ -23,13 +25,22 @@
     (-> request
         app
         :body
-        (json/read-str {:key-fn keyword})))
+        (json/read-json {:key-fn keyword})))
 
   (let [app (create-app)
-        request {:uri "/user" :request-method :get}]
+        request {:uri "/users/2" :request-method :get}]
     (-> request
         app
         :body
-        (json/read-str {:key-fn keyword})))
+        (json/read-json {:key-fn keyword})))
 
+  (let [app (create-app)
+        request {:uri "/users/5" 
+                 :request-method :patch
+                 :body {:firstname "kiigan" 
+                        :lastname "korinzu"}}]
+    (-> request
+        app
+        :body 
+        (json/read-json {:key-fn keyword})))
   ())

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -2,14 +2,23 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn handler [{:keys [ds params] :as _request}]
-  (->> [:path :id]
-       (get-in params)
+(defn get-handler [{:keys [ds path-params] :as _request}]
+  (->> path-params
        (services/user ds)
        (assoc {} :user)
        (res/response)))
 
+(defn patch-handler [{:keys [ds body path-params] :as _request}]
+  (services/update-user! ds 
+                         {:id (:id path-params) 
+                          :values body})
+  (res/response {:message "successfully updated user"}))
+
 (comment
   (require '[source.db.interface :as db])
-  (handler {:ds (db/ds :master) :params {:path "1"}})
+  (get-handler {:ds (db/ds :master) :path-params {:id 5}})
+  (patch-handler {:ds (db/ds :master)
+                  :path-params {:id 5}
+                  :body {:firstname "kiigan"
+                         :lastname "korinzu"}})
   ())

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -2,23 +2,23 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn get-handler [{:keys [ds path-params] :as _request}]
+(defn get [{:keys [ds path-params] :as _request}]
   (->> path-params
        (services/user ds)
        (assoc {} :user)
        (res/response)))
 
-(defn patch-handler [{:keys [ds body path-params] :as _request}]
-  (services/update-user! ds 
-                         {:id (:id path-params) 
+(defn patch [{:keys [ds body path-params] :as _request}]
+  (services/update-user! ds
+                         {:id (:id path-params)
                           :values body})
   (res/response {:message "successfully updated user"}))
 
 (comment
   (require '[source.db.interface :as db])
-  (get-handler {:ds (db/ds :master) :path-params {:id 5}})
-  (patch-handler {:ds (db/ds :master)
-                  :path-params {:id 5}
-                  :body {:firstname "kiigan"
-                         :lastname "korinzu"}})
+  (get {:ds (db/ds :master) :path-params {:id 5}})
+  (patch {:ds (db/ds :master)
+          :path-params {:id 5}
+          :body {:firstname "kiigan"
+                 :lastname "korinzu"}})
   ())

--- a/src/source/routes/users.old.clj
+++ b/src/source/routes/users.old.clj
@@ -1,4 +1,4 @@
-(ns source.routes.users
+(ns source.routes.old.users
   (:require [source.middleware.auth.core :as auth]
             [ring.util.response :as res]
             [source.db.master.users :as db.users]

--- a/src/source/services/auth.clj
+++ b/src/source/services/auth.clj
@@ -20,5 +20,5 @@
 
 (comment
   (require '[source.db.interface :as db])
-  (login (db/ds :master) {:email "merveillevaneck@gmail.com" :type "admin"})
+  (login (db/ds :master) {:user {:email "merveillevaneck@gmail.com" :type "admin"}})
   ())

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -10,10 +10,13 @@
 (defn user [ds {:keys [_id] :as opts}]
   (users/user ds opts))
 
-(defn insert-user! [ds {:keys [id] :as opts}]
-  (users/delete-user! ds opts))
+(defn insert-user! [ds {:keys [_id] :as opts}]
+  (users/insert-user! ds opts))
 
-(defn login [ds {:keys [email] :as opts}]
+(defn update-user! [ds {:keys [_id _values _where] :as opts}]
+  (users/update-user! ds opts))
+
+(defn login [ds {:keys [_email] :as opts}]
   (auth/login ds opts))
 
 (defn register [ds user]
@@ -21,6 +24,6 @@
 
 (comment
   (users (db/ds :master))
-  (user (db/ds :master) {:id 1})
+  (user (db/ds :master) {:id 2})
   (login (db/ds :master) {:email "merveillevaneck@gmail.com"})
   ())

--- a/src/source/services/users.clj
+++ b/src/source/services/users.clj
@@ -30,6 +30,13 @@
        (merge opts)
        (db/delete! ds)))
 
+(defn update-user! [ds {:keys [id values where] :as opts}]
+  (->> {:tname :users
+        :values values
+        :where (if (some? id) [:= :id id] where)}
+       (merge opts)
+       (db/update! ds)))
+
 (comment
   (users (db/ds :master))
   (insert-user! (db/ds :master) {:email "merveillevaneck@gmail.com"
@@ -38,4 +45,8 @@
                                  :firstname "merv"
                                  :lastname "vaneck"
                                  :type "admin"})
+  (user (db/ds :master) {:id 5})
+  (update-user! (db/ds :master) {:id 5
+                                 :values {:firstname "kiigan"
+                                          :lastname "korinzu"}})
   ())


### PR DESCRIPTION
This PR adds all the missing routes to the reitit router and fixes typos and small import issues. In addition it also adds one service db function for updating users.

- **added get and patch user routes**
- **fixed auth routes**
- **added protected and admin routes**
