### PR TITLE
final routes needed to complete auth feature on the frontend

### DIFF
--- a/src/source/routes/business.clj
+++ b/src/source/routes/business.clj
@@ -1,0 +1,18 @@
+(ns source.routes.business
+  (:require [source.services.businesses :as businesses]
+            [ring.util.response :as res]
+            [source.db.util :as db.util]))
+
+(defn post [{:keys [ds body] :as _request}]
+  (businesses/insert-business! ds body)
+  (res/response {:message "successfully added business"}))
+
+(defn patch [{:keys [ds body path-params] :as _request}]
+  (businesses/update-business! ds {:id (:id path-params)
+                                   :values body})
+  (res/response {:message "successfully updated business"}))
+
+(comment
+  (require '[source.db.util :as db.util])
+  (get {:ds (db.util/conn)})
+  ())

--- a/src/source/routes/businesses.clj
+++ b/src/source/routes/businesses.clj
@@ -1,0 +1,11 @@
+(ns source.routes.businesses
+  (:require [source.services.businesses :as businesses]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [ds] :as _request}]
+  (res/response {:businesses (businesses/businesses ds)}))
+
+(comment
+  (require '[source.db.util :as db.util])
+  (get {:ds (db.util/conn)})
+  ())

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -10,7 +10,10 @@
             [source.routes.google-launch :as google-launch]
             [source.routes.google-redirect :as google-redirect]
             [source.routes.admin :as admin]
-            [source.routes.authorized :as authorized]))
+            [source.routes.authorized :as authorized]
+            [source.routes.business :as business]
+            [source.routes.businesses :as businesses]
+            [source.routes.sectors :as sectors]))
 
 (defn create-app []
   (let [ds (db/ds :master)]
@@ -19,9 +22,15 @@
       [["/" {:middleware [[mw/apply-generic :ds ds]]}
         ["" (fn [_request] {:status 200 :body {:message "success"}})]
         ["users"
-         ["" users/handler]
+         ["" {:get users/get}]
          ["/:id" {:get user/get
                   :patch user/patch}]]
+        ["businesses"
+         ["" {:get businesses/get
+              :post business/post}]
+         ["/:id" {:patch business/patch}]]
+        ["sectors"
+         ["" {:get sectors/get}]]
         ["login" {:post login/post}]
         ["register" {:post register/post}]
         ["oauth2"
@@ -90,8 +99,35 @@
         (json/read-json {:key-fn keyword})))
 
   (let [app (create-app)
-        request {:uri "/bundle/test-interaction"
-                 :query-params {"uuid" "7eff22ca788cd1df"}
+        request {:uri "/businesses"
+                 :request-method :get}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/businesses"
+                 :request-method :post
+                 :body {:name "modulr"
+                        :url "https://modulr.com"}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/businesses/1"
+                 :request-method :patch
+                 :body {:name "thebest"
+                        :url "http://thebest.com"}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/sectors"
                  :request-method :get}]
     (-> request
         app

--- a/src/source/routes/sectors.clj
+++ b/src/source/routes/sectors.clj
@@ -1,0 +1,11 @@
+(ns source.routes.sectors
+  (:require [source.services.sectors :as sectors]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [ds] :as _request}]
+  (res/response {:sectors (sectors/sectors ds)}))
+
+(comment
+  (require '[source.db.util :as db.util])
+  (get {:ds (db.util/conn)})
+  ())

--- a/src/source/routes/users.clj
+++ b/src/source/routes/users.clj
@@ -2,10 +2,10 @@
   (:require [ring.util.response :as res]
             [source.services.users :as users]))
 
-(defn handler [{:keys [ds] :as _request}]
+(defn get [{:keys [ds] :as _request}]
   (res/response {:users (users/users ds)}))
 
 (comment
   (require '[source.db.interface :as db])
-  (handler {:ds (db/ds :master)})
+  (get {:ds (db/ds :master)})
   ())

--- a/src/source/services/businesses.clj
+++ b/src/source/services/businesses.clj
@@ -1,0 +1,21 @@
+(ns source.services.businesses
+  (:require [source.db.interface :as db]))
+
+(defn businesses
+  ([ds] (businesses ds {}))
+  ([ds opts]
+   (->> {:tname :businesses}
+        (merge opts)
+        (db/find ds))))
+
+(defn insert-business! [ds business]
+  (->> {:tname :businesses
+        :data business}
+       (db/insert! ds)))
+
+(defn update-business! [ds {:keys [id values where] :as opts}]
+  (->> {:tname :businesses
+        :values values
+        :where (if (some? id) [:= :id id] where)}
+       (merge opts)
+       (db/update! ds)))

--- a/src/source/services/sectors.clj
+++ b/src/source/services/sectors.clj
@@ -1,0 +1,9 @@
+(ns source.services.sectors
+  (:require [source.db.interface :as db]))
+
+(defn sectors
+  ([ds] (sectors ds {}))
+  ([ds opts]
+   (->> {:tname :sectors}
+        (merge opts)
+        (db/find ds))))


### PR DESCRIPTION
Added get post and patch routes for working with the businesses table, this allows getting all businesses, inserting a business and updating a business by id.
Added get route for sectors to get all sectors.
Updated migration to use jdbc instead of db.util, this fixes an issue where db.util/conn would reject the migrate db.
