### PR TITLE
implemented swagger documentation for reitit routes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,6 @@
         ring/ring-json {:mvn/version "0.5.1"}
         ring/ring-defaults {:mvn/version "0.6.0"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
-        metosin/jsonista {:mvn/version "0.3.13"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.994"}
         org.xerial/sqlite-jdbc {:mvn/version "3.49.1.0"}
         buddy/buddy-core {:mvn/version "1.12.0-430"}
@@ -28,4 +27,8 @@
         com.kepler16/mallard {:mvn/version "3.2.1"}
         com.kepler16/mallard-sqlite-store {:mvn/version "3.2.1"}
         com.github.seancorfield/honeysql {:mvn/version "2.7.1310"}
-        metosin/reitit {:mvn/version "0.9.1"}}}
+        metosin/jsonista {:mvn/version "0.3.13"}
+        metosin/reitit {:mvn/version "0.9.1"}
+        metosin/reitit-middleware {:mvn/version "0.9.1"}
+        metosin/reitit-swagger {:mvn/version "0.9.1"}
+        metosin/reitit-swagger-ui {:mvn/version "0.9.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -29,6 +29,5 @@
         com.github.seancorfield/honeysql {:mvn/version "2.7.1310"}
         metosin/jsonista {:mvn/version "0.3.13"}
         metosin/reitit {:mvn/version "0.9.1"}
-        metosin/reitit-middleware {:mvn/version "0.9.1"}
         metosin/reitit-swagger {:mvn/version "0.9.1"}
         metosin/reitit-swagger-ui {:mvn/version "0.9.1"}}}

--- a/src/source/routes/admin.clj
+++ b/src/source/routes/admin.clj
@@ -19,9 +19,17 @@
       :else
       (let [pw (pw/hash-password password)
             new-user (-> (assoc body
-                            :password pw
-                            :type "admin")
+                                :password pw
+                                :type "admin")
                          (dissoc :confirm-password))]
         (users/insert-user! ds {:data new-user})
         {:status 200 :body {:message "successfully created user"}}))))
 
+(def post-parameters {:body [:map
+                             [:email :string]
+                             [:password :string]
+                             [:confirm-password :string]]})
+
+(def post-responses {201 {:body [:map [:message :string]]}
+                     401 {:body [:map [:message :string]]}
+                     403 {:body [:map [:message :string]]}})

--- a/src/source/routes/admin.clj
+++ b/src/source/routes/admin.clj
@@ -3,7 +3,17 @@
             [source.db.util :as db.util]
             [source.password :as pw]))
 
-(defn post [{:keys [body] :as _request}]
+(defn post
+  {:summary "registers an admin user"
+   :parameters {:body [:map
+                       [:email :string]
+                       [:password :string]
+                       [:confirm-password :string]]}
+   :responses {201 {:body [:map [:message :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [body] :as _request}]
   (let [ds (db.util/conn :master)
         user (users/user
               ds
@@ -24,12 +34,3 @@
                          (dissoc :confirm-password))]
         (users/insert-user! ds {:data new-user})
         {:status 200 :body {:message "successfully created user"}}))))
-
-(def post-parameters {:body [:map
-                             [:email :string]
-                             [:password :string]
-                             [:confirm-password :string]]})
-
-(def post-responses {201 {:body [:map [:message :string]]}
-                     401 {:body [:map [:message :string]]}
-                     403 {:body [:map [:message :string]]}})

--- a/src/source/routes/authorized.clj
+++ b/src/source/routes/authorized.clj
@@ -1,11 +1,13 @@
 (ns source.routes.authorized)
 
-(defn get [{:keys [user] :as _request}]
+(defn get
+  {:summary "checks if authenticated"
+   :responses {200 {:body [:map
+                           [:user
+                            [:map
+                             [:id :int]
+                             [:type [:enum "creator" "distributor" "admin"]]]]]}}}
+
+  [{:keys [user] :as _request}]
   {:status 200
    :body {:user user}})
-
-(def get-responses {200 {:body [:map
-                                [:user
-                                 [:map
-                                  [:id :int]
-                                  [:type [:enum "creator" "distributor" "admin"]]]]]}})

--- a/src/source/routes/authorized.clj
+++ b/src/source/routes/authorized.clj
@@ -4,3 +4,8 @@
   {:status 200
    :body {:user user}})
 
+(def get-responses {200 {:body [:map
+                                [:user
+                                 [:map
+                                  [:id :int]
+                                  [:type [:enum "creator" "distributor" "admin"]]]]]}})

--- a/src/source/routes/business.clj
+++ b/src/source/routes/business.clj
@@ -2,30 +2,31 @@
   (:require [source.services.businesses :as businesses]
             [ring.util.response :as res]))
 
-(defn post [{:keys [ds body] :as _request}]
+(defn post
+  {:summary "insert a business"
+   :parameters {:body [:map
+                       [:name :string]
+                       [:url {:optional true} :string]
+                       [:linkedin {:optional true} :string]
+                       [:twitter {:optional true} :string]]}
+   :responses {201 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds body] :as _request}]
   (businesses/insert-business! ds body)
   (res/response {:message "successfully added business"}))
 
-(def post-parameters {:body [:map
-                             [:name :string]
-                             [:url {:optional true} :string]
-                             [:linkedin {:optional true} :string]
-                             [:twitter {:optional true} :string]]})
+(defn patch
+  {:summary "update a business by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "business id"} :int]]
+                :body [:map
+                       [:name :string]
+                       [:url {:optional true} :string]
+                       [:linkedin {:optional true} :string]
+                       [:twitter {:optional true} :string]]}
+   :responses {200 {:body [:map [:message :string]]}}}
 
-(def post-responses {201 {:body [:map [:message :string]]}})
-
-(defn patch [{:keys [ds body path-params] :as _request}]
+  [{:keys [ds body path-params] :as _request}]
   (businesses/update-business! ds {:id (:id path-params)
                                    :values body})
   (res/response {:message "successfully updated business"}))
-
-(def patch-parameters {:path [:map [:id {:title "id"
-                                         :description "business id"} :int]]
-                       :body [:map
-                              [:name :string]
-                              [:url {:optional true} :string]
-                              [:linkedin {:optional true} :string]
-                              [:twitter {:optional true} :string]]})
-
-(def patch-responses {200 {:body [:map [:message :string]]}})
-

--- a/src/source/routes/business.clj
+++ b/src/source/routes/business.clj
@@ -3,11 +3,29 @@
             [ring.util.response :as res]))
 
 (defn post [{:keys [ds body] :as _request}]
-  (businesses/insert-business! ds {:data body})
+  (businesses/insert-business! ds body)
   (res/response {:message "successfully added business"}))
+
+(def post-parameters {:body [:map
+                             [:name :string]
+                             [:url {:optional true} :string]
+                             [:linkedin {:optional true} :string]
+                             [:twitter {:optional true} :string]]})
+
+(def post-responses {201 {:body [:map [:message :string]]}})
 
 (defn patch [{:keys [ds body path-params] :as _request}]
   (businesses/update-business! ds {:id (:id path-params)
                                    :values body})
   (res/response {:message "successfully updated business"}))
+
+(def patch-parameters {:path [:map [:id {:title "id"
+                                         :description "business id"} :int]]
+                       :body [:map
+                              [:name :string]
+                              [:url {:optional true} :string]
+                              [:linkedin {:optional true} :string]
+                              [:twitter {:optional true} :string]]})
+
+(def patch-responses {200 {:body [:map [:message :string]]}})
 

--- a/src/source/routes/businesses.clj
+++ b/src/source/routes/businesses.clj
@@ -2,23 +2,24 @@
   (:require [source.services.businesses :as businesses]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds] :as _request}]
+(defn get
+  {:summary "get all businesses"
+   :parameters {:body [:map
+                       [:name :string]
+                       [:url {:optional true} :string]
+                       [:linkedin {:optional true} :string]
+                       [:twitter {:optional true} :string]]}
+   :responses {200 {:body [:map
+                           [:businesses
+                            [:map
+                             [:id :int]
+                             [:name :string]
+                             [:url {:optional true} :string]
+                             [:linkedin {:optional true} :string]
+                             [:twitter {:optional true} :string]]]]}}}
+
+  [{:keys [ds] :as _request}]
   (res/response {:businesses (businesses/businesses ds)}))
-
-(def get-parameters {:body [:map
-                            [:name :string]
-                            [:url {:optional true} :string]
-                            [:linkedin {:optional true} :string]
-                            [:twitter {:optional true} :string]]})
-
-(def get-responses {200 {:body [:map
-                                [:businesses
-                                 [:map
-                                  [:id :int]
-                                  [:name :string]
-                                  [:url {:optional true} :string]
-                                  [:linkedin {:optional true} :string]
-                                  [:twitter {:optional true} :string]]]]}})
 
 (comment
   (require '[source.db.util :as db.util])

--- a/src/source/routes/businesses.clj
+++ b/src/source/routes/businesses.clj
@@ -5,6 +5,21 @@
 (defn get [{:keys [ds] :as _request}]
   (res/response {:businesses (businesses/businesses ds)}))
 
+(def get-parameters {:body [:map
+                            [:name :string]
+                            [:url {:optional true} :string]
+                            [:linkedin {:optional true} :string]
+                            [:twitter {:optional true} :string]]})
+
+(def get-responses {200 {:body [:map
+                                [:businesses
+                                 [:map
+                                  [:id :int]
+                                  [:name :string]
+                                  [:url {:optional true} :string]
+                                  [:linkedin {:optional true} :string]
+                                  [:twitter {:optional true} :string]]]]}})
+
 (comment
   (require '[source.db.util :as db.util])
   (get {:ds (db.util/conn)})

--- a/src/source/routes/login.clj
+++ b/src/source/routes/login.clj
@@ -14,6 +14,27 @@
 
       (res/response (auth/login ds {:user user})))))
 
+(def post-parameters {:body [:map
+                             [:email :string]
+                             [:password :string]]})
+
+(def post-responses {200 {:body [:map
+                                 [:user
+                                  [:map
+                                   [:id :int]
+                                   [:address {:optional true} :string]
+                                   [:profile-image {:optional true} :string]
+                                   [:email :string]
+                                   [:firstname {:optional true} :string]
+                                   [:lastname {:optional true} :string]
+                                   [:type [:enum "creator" "distributor" "admin"]]
+                                   [:email-verified {:optional true} :int]
+                                   [:onboarded {:optional true} :int]
+                                   [:mobile {:optional true} :string]]]
+                                 [:access-token :string]
+                                 [:refresh-token :string]]}
+                     401 {:body [:map [:message :string]]}})
+
 (comment
   (require '[source.db.interface :as db])
   (post {:ds (db/ds :master) :body {:email "toast@toast.com" :password "poop"}})

--- a/src/source/routes/login.clj
+++ b/src/source/routes/login.clj
@@ -4,7 +4,29 @@
             [source.services.users :as users]
             [source.password :as pw]))
 
-(defn post [{:keys [ds body] :as _request}]
+(defn post
+  {:summary "get user data and access token provided valid credentials"
+   :parameters {:body [:map
+                       [:email :string]
+                       [:password :string]]}
+   :responses {200 {:body [:map
+                           [:user
+                            [:map
+                             [:id :int]
+                             [:address {:optional true} :string]
+                             [:profile-image {:optional true} :string]
+                             [:email :string]
+                             [:firstname {:optional true} :string]
+                             [:lastname {:optional true} :string]
+                             [:type [:enum "creator" "distributor" "admin"]]
+                             [:email-verified {:optional true} :int]
+                             [:onboarded {:optional true} :int]
+                             [:mobile {:optional true} :string]]]
+                           [:access-token :string]
+                           [:refresh-token :string]]}
+               401 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds body] :as _request}]
   (let [{:keys [email password]} body
         user (users/user ds {:where [:= :email email]})]
     (if
@@ -13,27 +35,6 @@
       {:status 401 :body {:message "Invalid username or password!"}}
 
       (res/response (auth/login ds {:user user})))))
-
-(def post-parameters {:body [:map
-                             [:email :string]
-                             [:password :string]]})
-
-(def post-responses {200 {:body [:map
-                                 [:user
-                                  [:map
-                                   [:id :int]
-                                   [:address {:optional true} :string]
-                                   [:profile-image {:optional true} :string]
-                                   [:email :string]
-                                   [:firstname {:optional true} :string]
-                                   [:lastname {:optional true} :string]
-                                   [:type [:enum "creator" "distributor" "admin"]]
-                                   [:email-verified {:optional true} :int]
-                                   [:onboarded {:optional true} :int]
-                                   [:mobile {:optional true} :string]]]
-                                 [:access-token :string]
-                                 [:refresh-token :string]]}
-                     401 {:body [:map [:message :string]]}})
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/routes/register.clj
+++ b/src/source/routes/register.clj
@@ -2,7 +2,29 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn post [{:keys [ds body] :as _request}]
+(defn post
+  {:summary "register a new user"
+   :parameters {:body [:map
+                       [:email :string]
+                       [:password :string]
+                       [:confirm-password :string]]}
+   :responses {200 {:body [:map
+                           [:user
+                            [:map
+                             [:id :int]
+                             [:address {:optional true} :string]
+                             [:profile-image {:optional true} :string]
+                             [:email :string]
+                             [:firstname {:optional true} :string]
+                             [:lastname {:optional true} :string]
+                             [:type [:enum "creator" "distributor" "admin"]]
+                             [:email-verified {:optional true} :int]
+                             [:onboarded {:optional true} :int]
+                             [:mobile {:optional true} :string]]]
+                           [:access-token :string]
+                           [:refresh-token :string]]}}}
+
+  [{:keys [ds body] :as _request}]
   ;;TODO: needs schema validation here
   (let [{:keys [email password confirm-password]} body
         existing-user (services/user ds {:where [:= :email email]})]
@@ -16,27 +38,6 @@
       :else
       (-> (services/register ds body)
           (res/response)))))
-
-(def post-parameters {:body [:map
-                             [:email :string]
-                             [:password :string]
-                             [:confirm-password :string]]})
-
-(def post-responses {200 {:body [:map
-                                 [:user
-                                  [:map
-                                   [:id :int]
-                                   [:address {:optional true} :string]
-                                   [:profile-image {:optional true} :string]
-                                   [:email :string]
-                                   [:firstname {:optional true} :string]
-                                   [:lastname {:optional true} :string]
-                                   [:type [:enum "creator" "distributor" "admin"]]
-                                   [:email-verified {:optional true} :int]
-                                   [:onboarded {:optional true} :int]
-                                   [:mobile {:optional true} :string]]]
-                                 [:access-token :string]
-                                 [:refresh-token :string]]}})
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/routes/register.clj
+++ b/src/source/routes/register.clj
@@ -17,6 +17,27 @@
       (-> (services/register ds body)
           (res/response)))))
 
+(def post-parameters {:body [:map
+                             [:email :string]
+                             [:password :string]
+                             [:confirm-password :string]]})
+
+(def post-responses {200 {:body [:map
+                                 [:user
+                                  [:map
+                                   [:id :int]
+                                   [:address {:optional true} :string]
+                                   [:profile-image {:optional true} :string]
+                                   [:email :string]
+                                   [:firstname {:optional true} :string]
+                                   [:lastname {:optional true} :string]
+                                   [:type [:enum "creator" "distributor" "admin"]]
+                                   [:email-verified {:optional true} :int]
+                                   [:onboarded {:optional true} :int]
+                                   [:mobile {:optional true} :string]]]
+                                 [:access-token :string]
+                                 [:refresh-token :string]]}})
+
 (comment
   (require '[source.db.interface :as db])
   (post {:ds (db/ds :master) :body {:email "test@test.com"

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -29,7 +29,9 @@
         {:get {:no-doc true
                :swagger {:info {:title "source-api"
                                 :description "swagger docs for source api with malli and reitit-ring"}
-                         :securityDefinitions {"auth" {:type :bearer}}}
+                         :securityDefinitions {"auth" {:type :apiKey
+                                                       :in :header
+                                                       :name "Authorization"}}}
                :handler (swagger/create-swagger-handler)}}]
        ["/users" {:middleware [[mw/apply-auth {:required-type :admin}]]
                   :tags #{"admin-only"}

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -34,7 +34,7 @@
                                                        :name "Authorization"}}}
                :handler (swagger/create-swagger-handler)}}]
        ["/users" {:middleware [[mw/apply-auth {:required-type :admin}]]
-                  :tags #{"admin-only"}
+                  :tags #{"users"}
                   :swagger {:security [{"auth" []}]}}
         ["" {:get {:summary "get all users"
                    :responses {200 {:body [:map
@@ -102,7 +102,9 @@
                                      401 {:body [:map [:message :string]]}
                                      403 {:body [:map [:message :string]]}}
                          :handler user/patch}}]]
-       ["/businesses"
+       ["/businesses" {:middleware [[mw/apply-auth {:required-type :admin}]]
+                       :tags #{"businesses"}
+                       :swagger {:security [{"auth" []}]}}
         ["" {:get {:summary "get all businesses"
                    :parameters {:body [:map
                                        [:name :string]
@@ -136,7 +138,7 @@
                                              [:twitter {:optional true} :string]]}
                          :responses {200 {:body [:map [:message :string]]}}
                          :handler business/patch}}]]
-       ["/sectors"
+       ["/sectors" {:tags #{"sectors"}}
         ["" {:get {:summary "get all sectors"
                    :responses {200 {:body [:map
                                            [:sectors
@@ -144,48 +146,50 @@
                                              [:id :int]
                                              [:name :string]]]]}}
                    :handler sectors/get}}]]
-       ["/login" {:post {:summary "get user data and access token provided valid login credentials"
-                         :parameters {:body [:map
-                                             [:email :string]
-                                             [:password :string]]}
-                         :responses {200 {:body [:map
-                                                 [:user
-                                                  [:map
-                                                   [:id :int]
-                                                   [:address {:optional true} :string]
-                                                   [:profile-image {:optional true} :string]
-                                                   [:email :string]
-                                                   [:firstname {:optional true} :string]
-                                                   [:lastname {:optional true} :string]
-                                                   [:type [:enum "creator" "distributor" "admin"]]
-                                                   [:email-verified {:optional true} :int]
-                                                   [:onboarded {:optional true} :int]
-                                                   [:mobile {:optional true} :string]]]
-                                                 [:access-token :string]
-                                                 [:refresh-token :string]]}
-                                     401 {:body [:map [:message :string]]}}
-                         :handler login/post}}]
-       ["/register" {:post {:summary "register a new user"
-                            :parameters {:body [:map
-                                                [:email :string]
-                                                [:password :string]
-                                                [:confirm-password :string]]}
-                            :responses {200 {:body [:map
-                                                    [:user
-                                                     [:map
-                                                      [:id :int]
-                                                      [:address {:optional true} :string]
-                                                      [:profile-image {:optional true} :string]
-                                                      [:email :string]
-                                                      [:firstname {:optional true} :string]
-                                                      [:lastname {:optional true} :string]
-                                                      [:type [:enum "creator" "distributor" "admin"]]
-                                                      [:email-verified {:optional true} :int]
-                                                      [:onboarded {:optional true} :int]
-                                                      [:mobile {:optional true} :string]]]
-                                                    [:access-token :string]
-                                                    [:refresh-token :string]]}}
-                            :handler register/post}}]
+       ["/login" {:tags #{"auth"}}
+        {:post {:summary "get user data and access token provided valid login credentials"
+                :parameters {:body [:map
+                                    [:email :string]
+                                    [:password :string]]}
+                :responses {200 {:body [:map
+                                        [:user
+                                         [:map
+                                          [:id :int]
+                                          [:address {:optional true} :string]
+                                          [:profile-image {:optional true} :string]
+                                          [:email :string]
+                                          [:firstname {:optional true} :string]
+                                          [:lastname {:optional true} :string]
+                                          [:type [:enum "creator" "distributor" "admin"]]
+                                          [:email-verified {:optional true} :int]
+                                          [:onboarded {:optional true} :int]
+                                          [:mobile {:optional true} :string]]]
+                                        [:access-token :string]
+                                        [:refresh-token :string]]}
+                            401 {:body [:map [:message :string]]}}
+                :handler login/post}}]
+       ["/register" {:tags #{"auth"}}
+        {:post {:summary "register a new user"
+                :parameters {:body [:map
+                                    [:email :string]
+                                    [:password :string]
+                                    [:confirm-password :string]]}
+                :responses {200 {:body [:map
+                                        [:user
+                                         [:map
+                                          [:id :int]
+                                          [:address {:optional true} :string]
+                                          [:profile-image {:optional true} :string]
+                                          [:email :string]
+                                          [:firstname {:optional true} :string]
+                                          [:lastname {:optional true} :string]
+                                          [:type [:enum "creator" "distributor" "admin"]]
+                                          [:email-verified {:optional true} :int]
+                                          [:onboarded {:optional true} :int]
+                                          [:mobile {:optional true} :string]]]
+                                        [:access-token :string]
+                                        [:refresh-token :string]]}}
+                :handler register/post}}]
        ["/oauth2" {:no-doc true}
         ["/google"
          ["" {:get google-launch/get}]
@@ -201,7 +205,7 @@
                                                         [:type [:enum "creator" "distributor" "admin"]]]]]}}
                               :handler authorized/get}}]]
        ["/admin" {:middleware [[mw/apply-auth {:required-type :admin}]]
-                  :tags #{"admin-only"}
+                  :tags #{"admin"}
                   :swagger {:security [{"auth" []}]}}
         ["/add-admin" {:post {:summary "registers an admin user [admins only]"
                               :parameters {:body [:map

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -35,158 +35,44 @@
                   :tags #{"users"}
                   :swagger {:security [{"auth" []}]}}
         ["" {:get {:summary "get all users"
-                   :responses {200 {:body [:map
-                                           [:users
-                                            [:vector
-                                             [:map
-                                              [:id :int]
-                                              [:address {:optional true} :string]
-                                              [:profile-image {:optional true} :string]
-                                              [:email :string]
-                                              [:firstname {:optional true} :string]
-                                              [:lastname {:optional true} :string]
-                                              [:type [:enum "creator" "distributor" "admin"]]
-                                              [:email-verified {:optional true} :int]
-                                              [:onboarded {:optional true} :int]
-                                              [:mobile {:optional true} :string]]]]]}
-                               401 {:body [:map [:message :string]]}
-                               403 {:body [:map [:message :string]]}}
+                   :responses users/get-responses
                    :handler users/get}}]
         ["/:id" {:get {:summary "get user by id"
-                       :parameters {:path [:map [:id {:title "id"
-                                                      :description "user id"} :int]]}
-                       :responses {200 {:body [:map
-                                               [:user
-                                                [:map
-                                                 [:id :int]
-                                                 [:address {:optional true} :string]
-                                                 [:profile-image {:optional true} :string]
-                                                 [:email :string]
-                                                 [:firstname {:optional true} :string]
-                                                 [:lastname {:optional true} :string]
-                                                 [:type [:enum "creator" "distributor" "admin"]]
-                                                 [:email-verified {:optional true} :int]
-                                                 [:onboarded {:optional true} :int]
-                                                 [:mobile {:optional true} :string]]]]}
-                                   401 {:body [:map [:message :string]]}
-                                   403 {:body [:map [:message :string]]}}
+                       :parameters user/get-parameters
+                       :responses user/get-responses
                        :handler user/get}
                  :patch {:summary "update user by id"
-                         :parameters {:path [:map [:id {:title "id"
-                                                        :description "user id"} :int]]
-                                      :body [:map
-                                             [:address {:optional true} :string]
-                                             [:profile-image {:optional true} :string]
-                                             [:email :string]
-                                             [:firstname {:optional true} :string]
-                                             [:lastname {:optional true} :string]
-                                             [:type [:enum "creator" "distributor" "admin"]]
-                                             [:email-verified {:optional true} :int]
-                                             [:onboarded {:optional true} :int]
-                                             [:mobile {:optional true} :string]]}
-                         :responses {200 {:body [:map
-                                                 [:user
-                                                  [:map
-                                                   [:id :int]
-                                                   [:address {:optional true} :string]
-                                                   [:profile-image {:optional true} :string]
-                                                   [:email :string]
-                                                   [:firstname {:optional true} :string]
-                                                   [:lastname {:optional true} :string]
-                                                   [:type [:enum "creator" "distributor" "admin"]]
-                                                   [:email-verified {:optional true} :int]
-                                                   [:onboarded {:optional true} :int]
-                                                   [:mobile {:optional true} :string]]]]}
-                                     401 {:body [:map [:message :string]]}
-                                     403 {:body [:map [:message :string]]}}
+                         :parameters user/patch-parameters
+                         :responses user/patch-responses
                          :handler user/patch}}]]
        ["/businesses" {:middleware [[mw/apply-auth {:required-type :admin}]]
                        :tags #{"businesses"}
                        :swagger {:security [{"auth" []}]}}
         ["" {:get {:summary "get all businesses"
-                   :parameters {:body [:map
-                                       [:name :string]
-                                       [:url {:optional true} :string]
-                                       [:linkedin {:optional true} :string]
-                                       [:twitter {:optional true} :string]]}
-                   :responses {200 {:body [:map
-                                           [:businesses
-                                            [:map
-                                             [:id :int]
-                                             [:name :string]
-                                             [:url {:optional true} :string]
-                                             [:linkedin {:optional true} :string]
-                                             [:twitter {:optional true} :string]]]]}}
+                   :parameters businesses/get-parameters
+                   :responses businesses/get-responses
                    :handler businesses/get}
              :post {:summary "insert a business"
-                    :parameters {:body [:map
-                                        [:name :string]
-                                        [:url {:optional true} :string]
-                                        [:linkedin {:optional true} :string]
-                                        [:twitter {:optional true} :string]]}
-                    :responses {201 {:body [:map [:message :string]]}}
+                    :parameters business/post-parameters
+                    :responses business/post-responses
                     :handler business/post}}]
         ["/:id" {:patch {:summary "update business by id"
-                         :parameters {:path [:map [:id {:title "id"
-                                                        :description "business id"} :int]]
-                                      :body [:map
-                                             [:name :string]
-                                             [:url {:optional true} :string]
-                                             [:linkedin {:optional true} :string]
-                                             [:twitter {:optional true} :string]]}
-                         :responses {200 {:body [:map [:message :string]]}}
+                         :parameters business/patch-parameters
+                         :responses business/patch-responses
                          :handler business/patch}}]]
        ["/sectors" {:tags #{"sectors"}}
         ["" {:get {:summary "get all sectors"
-                   :responses {200 {:body [:map
-                                           [:sectors
-                                            [:map
-                                             [:id :int]
-                                             [:name :string]]]]}}
+                   :responses sectors/get-responses
                    :handler sectors/get}}]]
        ["/login" {:tags #{"auth"}
                   :post {:summary "get user data and access token provided valid login credentials"
-                         :parameters {:body [:map
-                                             [:email :string]
-                                             [:password :string]]}
-                         :responses {200 {:body [:map
-                                                 [:user
-                                                  [:map
-                                                   [:id :int]
-                                                   [:address {:optional true} :string]
-                                                   [:profile-image {:optional true} :string]
-                                                   [:email :string]
-                                                   [:firstname {:optional true} :string]
-                                                   [:lastname {:optional true} :string]
-                                                   [:type [:enum "creator" "distributor" "admin"]]
-                                                   [:email-verified {:optional true} :int]
-                                                   [:onboarded {:optional true} :int]
-                                                   [:mobile {:optional true} :string]]]
-                                                 [:access-token :string]
-                                                 [:refresh-token :string]]}
-                                     401 {:body [:map [:message :string]]}}
+                         :parameters login/post-parameters
+                         :responses login/post-responses
                          :handler login/post}}]
        ["/register" {:tags #{"auth"}
                      :post {:summary "register a new user"
-                            :parameters {:body [:map
-                                                [:email :string]
-                                                [:password :string]
-                                                [:confirm-password :string]]}
-                            :responses {200 {:body [:map
-                                                    [:user
-                                                     [:map
-                                                      [:id :int]
-                                                      [:address {:optional true} :string]
-                                                      [:profile-image {:optional true} :string]
-                                                      [:email :string]
-                                                      [:firstname {:optional true} :string]
-                                                      [:lastname {:optional true} :string]
-                                                      [:type [:enum "creator" "distributor" "admin"]]
-                                                      [:email-verified {:optional true} :int]
-                                                      [:onboarded {:optional true} :int]
-                                                      [:mobile {:optional true} :string]]]
-                                                    [:access-token :string]
-                                                    [:refresh-token :string]]}}
+                            :parameters register/post-parameters
+                            :responses register/post-responses
                             :handler register/post}}]
        ["/oauth2" {:no-doc true}
         ["/google"
@@ -196,23 +82,14 @@
                       :tags #{"protected"}
                       :swagger {:security [{"auth" []}]}}
         ["/authorized" {:get {:summary "checks if authenticated"
-                              :responses {200 {:body [:map
-                                                      [:user
-                                                       [:map
-                                                        [:id :int]
-                                                        [:type [:enum "creator" "distributor" "admin"]]]]]}}
+                              :responses authorized/get-responses
                               :handler authorized/get}}]]
        ["/admin" {:middleware [[mw/apply-auth {:required-type :admin}]]
                   :tags #{"admin"}
                   :swagger {:security [{"auth" []}]}}
-        ["/add-admin" {:post {:summary "registers an admin user [admins only]"
-                              :parameters {:body [:map
-                                                  [:email :string]
-                                                  [:password :string]
-                                                  [:confirm-password :string]]}
-                              :responses {201 {:body [:map [:message :string]]}
-                                          401 {:body [:map [:message :string]]}
-                                          403 {:body [:map [:message :string]]}}
+        ["/add-admin" {:post {:summary "registers an admin user"
+                              :parameters admin/post-parameters
+                              :responses admin/post-responses
                               :handler admin/post}}]]]
 
       {:data {:middleware [[mw/apply-generic :ds ds]]}})

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -28,9 +28,12 @@
       [["/swagger.json"
         {:get {:no-doc true
                :swagger {:info {:title "source-api"
-                                :description "swagger docs for source api with malli and reitit-ring"}}
+                                :description "swagger docs for source api with malli and reitit-ring"}
+                         :securityDefinitions {"auth" {:type :bearer}}}
                :handler (swagger/create-swagger-handler)}}]
-       ["/users" {:middleware [[mw/apply-auth {:required-type :admin}]]}
+       ["/users" {:middleware [[mw/apply-auth {:required-type :admin}]]
+                  :tags #{"admin-only"}
+                  :swagger {:security [{"auth" []}]}}
         ["" {:get {:summary "get all users"
                    :responses {200 {:body [:map
                                            [:users
@@ -185,7 +188,9 @@
         ["/google"
          ["" {:get google-launch/get}]
          ["/callback" {:get google-redirect/get}]]]
-       ["/protected" {:middleware [[mw/apply-auth]]}
+       ["/protected" {:middleware [[mw/apply-auth]]
+                      :tags #{"protected"}
+                      :swagger {:security [{"auth" []}]}}
         ["/authorized" {:get {:summary "checks if authenticated"
                               :responses {200 {:body [:map
                                                       [:user
@@ -193,7 +198,9 @@
                                                         [:id :int]
                                                         [:type [:enum "creator" "distributor" "admin"]]]]]}}
                               :handler authorized/get}}]]
-       ["/admin" {:middleware [[mw/apply-auth {:required-type :admin}]]}
+       ["/admin" {:middleware [[mw/apply-auth {:required-type :admin}]]
+                  :tags #{"admin-only"}
+                  :swagger {:security [{"auth" []}]}}
         ["/add-admin" {:post {:summary "registers an admin user [admins only]"
                               :parameters {:body [:map
                                                   [:email :string]

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -4,8 +4,6 @@
             [reitit.swagger-ui :as swagger-ui]
             [reitit.coercion.malli]
             [reitit.ring.malli]
-            [malli.util :as mu]
-            [muuntaja.core :as muuntaja]
             [source.middleware.interface :as mw]
             [source.db.interface :as db]
             [clojure.data.json :as json]
@@ -217,14 +215,7 @@
                                           403 {:body [:map [:message :string]]}}
                               :handler admin/post}}]]]
 
-      {:data {:coercion (reitit.coercion.malli/create
-                         {:error-keys #{#_:type :coercion :in :schema :value :errors :humanized #_:transformed}
-                          :compile mu/closed-schema
-                          :strip-extra-keys true
-                          :default-values true
-                          :options nil})
-              :muuntaja muuntaja/instance
-              :middleware [[mw/apply-generic :ds ds]]}})
+      {:data {:middleware [[mw/apply-generic :ds ds]]}})
      (ring/routes
       (swagger-ui/create-swagger-ui-handler {:path "/"})
       (ring/create-default-handler)))))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -144,50 +144,50 @@
                                              [:id :int]
                                              [:name :string]]]]}}
                    :handler sectors/get}}]]
-       ["/login" {:tags #{"auth"}}
-        {:post {:summary "get user data and access token provided valid login credentials"
-                :parameters {:body [:map
-                                    [:email :string]
-                                    [:password :string]]}
-                :responses {200 {:body [:map
-                                        [:user
-                                         [:map
-                                          [:id :int]
-                                          [:address {:optional true} :string]
-                                          [:profile-image {:optional true} :string]
-                                          [:email :string]
-                                          [:firstname {:optional true} :string]
-                                          [:lastname {:optional true} :string]
-                                          [:type [:enum "creator" "distributor" "admin"]]
-                                          [:email-verified {:optional true} :int]
-                                          [:onboarded {:optional true} :int]
-                                          [:mobile {:optional true} :string]]]
-                                        [:access-token :string]
-                                        [:refresh-token :string]]}
-                            401 {:body [:map [:message :string]]}}
-                :handler login/post}}]
-       ["/register" {:tags #{"auth"}}
-        {:post {:summary "register a new user"
-                :parameters {:body [:map
-                                    [:email :string]
-                                    [:password :string]
-                                    [:confirm-password :string]]}
-                :responses {200 {:body [:map
-                                        [:user
-                                         [:map
-                                          [:id :int]
-                                          [:address {:optional true} :string]
-                                          [:profile-image {:optional true} :string]
-                                          [:email :string]
-                                          [:firstname {:optional true} :string]
-                                          [:lastname {:optional true} :string]
-                                          [:type [:enum "creator" "distributor" "admin"]]
-                                          [:email-verified {:optional true} :int]
-                                          [:onboarded {:optional true} :int]
-                                          [:mobile {:optional true} :string]]]
-                                        [:access-token :string]
-                                        [:refresh-token :string]]}}
-                :handler register/post}}]
+       ["/login" {:tags #{"auth"}
+                  :post {:summary "get user data and access token provided valid login credentials"
+                         :parameters {:body [:map
+                                             [:email :string]
+                                             [:password :string]]}
+                         :responses {200 {:body [:map
+                                                 [:user
+                                                  [:map
+                                                   [:id :int]
+                                                   [:address {:optional true} :string]
+                                                   [:profile-image {:optional true} :string]
+                                                   [:email :string]
+                                                   [:firstname {:optional true} :string]
+                                                   [:lastname {:optional true} :string]
+                                                   [:type [:enum "creator" "distributor" "admin"]]
+                                                   [:email-verified {:optional true} :int]
+                                                   [:onboarded {:optional true} :int]
+                                                   [:mobile {:optional true} :string]]]
+                                                 [:access-token :string]
+                                                 [:refresh-token :string]]}
+                                     401 {:body [:map [:message :string]]}}
+                         :handler login/post}}]
+       ["/register" {:tags #{"auth"}
+                     :post {:summary "register a new user"
+                            :parameters {:body [:map
+                                                [:email :string]
+                                                [:password :string]
+                                                [:confirm-password :string]]}
+                            :responses {200 {:body [:map
+                                                    [:user
+                                                     [:map
+                                                      [:id :int]
+                                                      [:address {:optional true} :string]
+                                                      [:profile-image {:optional true} :string]
+                                                      [:email :string]
+                                                      [:firstname {:optional true} :string]
+                                                      [:lastname {:optional true} :string]
+                                                      [:type [:enum "creator" "distributor" "admin"]]
+                                                      [:email-verified {:optional true} :int]
+                                                      [:onboarded {:optional true} :int]
+                                                      [:mobile {:optional true} :string]]]
+                                                    [:access-token :string]
+                                                    [:refresh-token :string]]}}
+                            :handler register/post}}]
        ["/oauth2" {:no-doc true}
         ["/google"
          ["" {:get google-launch/get}]

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -46,8 +46,8 @@
                                               [:firstname {:optional true} :string]
                                               [:lastname {:optional true} :string]
                                               [:type [:enum "creator" "distributor" "admin"]]
-                                              [:email-verified :int]
-                                              [:onboarded :int]
+                                              [:email-verified {:optional true} :int]
+                                              [:onboarded {:optional true} :int]
                                               [:mobile {:optional true} :string]]]]]}
                                401 {:body [:map [:message :string]]}
                                403 {:body [:map [:message :string]]}}
@@ -65,8 +65,8 @@
                                                  [:firstname {:optional true} :string]
                                                  [:lastname {:optional true} :string]
                                                  [:type [:enum "creator" "distributor" "admin"]]
-                                                 [:email-verified :int]
-                                                 [:onboarded :int]
+                                                 [:email-verified {:optional true} :int]
+                                                 [:onboarded {:optional true} :int]
                                                  [:mobile {:optional true} :string]]]]}
                                    401 {:body [:map [:message :string]]}
                                    403 {:body [:map [:message :string]]}}
@@ -81,8 +81,8 @@
                                              [:firstname {:optional true} :string]
                                              [:lastname {:optional true} :string]
                                              [:type [:enum "creator" "distributor" "admin"]]
-                                             [:email-verified :int]
-                                             [:onboarded :int]
+                                             [:email-verified {:optional true} :int]
+                                             [:onboarded {:optional true} :int]
                                              [:mobile {:optional true} :string]]}
                          :responses {200 {:body [:map
                                                  [:user
@@ -94,8 +94,8 @@
                                                    [:firstname {:optional true} :string]
                                                    [:lastname {:optional true} :string]
                                                    [:type [:enum "creator" "distributor" "admin"]]
-                                                   [:email-verified :int]
-                                                   [:onboarded :int]
+                                                   [:email-verified {:optional true} :int]
+                                                   [:onboarded {:optional true} :int]
                                                    [:mobile {:optional true} :string]]]]}
                                      401 {:body [:map [:message :string]]}
                                      403 {:body [:map [:message :string]]}}
@@ -156,8 +156,8 @@
                                                    [:firstname {:optional true} :string]
                                                    [:lastname {:optional true} :string]
                                                    [:type [:enum "creator" "distributor" "admin"]]
-                                                   [:email-verified :int]
-                                                   [:onboarded :int]
+                                                   [:email-verified {:optional true} :int]
+                                                   [:onboarded {:optional true} :int]
                                                    [:mobile {:optional true} :string]]]
                                                  [:access-token :string]
                                                  [:refresh-token :string]]}
@@ -178,8 +178,8 @@
                                                       [:firstname {:optional true} :string]
                                                       [:lastname {:optional true} :string]
                                                       [:type [:enum "creator" "distributor" "admin"]]
-                                                      [:email-verified :int]
-                                                      [:onboarded :int]
+                                                      [:email-verified {:optional true} :int]
+                                                      [:onboarded {:optional true} :int]
                                                       [:mobile {:optional true} :string]]]
                                                     [:access-token :string]
                                                     [:refresh-token :string]]}}

--- a/src/source/routes/sectors.clj
+++ b/src/source/routes/sectors.clj
@@ -2,14 +2,16 @@
   (:require [source.services.sectors :as sectors]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds] :as _request}]
-  (res/response {:sectors (sectors/sectors ds)}))
+(defn get
+  {:summary "get all sectors"
+   :responses {200 {:body [:map
+                           [:sectors
+                            [:map
+                             [:id :int]
+                             [:name :string]]]]}}}
 
-(def get-responses {200 {:body [:map
-                                [:sectors
-                                 [:map
-                                  [:id :int]
-                                  [:name :string]]]]}})
+  [{:keys [ds] :as _request}]
+  (res/response {:sectors (sectors/sectors ds)}))
 
 (comment
   (require '[source.db.util :as db.util])

--- a/src/source/routes/sectors.clj
+++ b/src/source/routes/sectors.clj
@@ -5,6 +5,12 @@
 (defn get [{:keys [ds] :as _request}]
   (res/response {:sectors (sectors/sectors ds)}))
 
+(def get-responses {200 {:body [:map
+                                [:sectors
+                                 [:map
+                                  [:id :int]
+                                  [:name :string]]]]}})
+
 (comment
   (require '[source.db.util :as db.util])
   (get {:ds (db.util/conn)})

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -7,11 +7,59 @@
                   (services/user ds))]
     (res/response (assoc {} :user (dissoc user :password)))))
 
+(def get-parameters {:path [:map [:id {:title "id"
+                                       :description "user id"} :int]]})
+
+(def get-responses {200 {:body [:map
+                                [:user
+                                 [:map
+                                  [:id :int]
+                                  [:address {:optional true} :string]
+                                  [:profile-image {:optional true} :string]
+                                  [:email :string]
+                                  [:firstname {:optional true} :string]
+                                  [:lastname {:optional true} :string]
+                                  [:type [:enum "creator" "distributor" "admin"]]
+                                  [:email-verified {:optional true} :int]
+                                  [:onboarded {:optional true} :int]
+                                  [:mobile {:optional true} :string]]]]}
+                    401 {:body [:map [:message :string]]}
+                    403 {:body [:map [:message :string]]}})
+
 (defn patch [{:keys [ds body path-params] :as _request}]
   (services/update-user! ds
                          {:id (:id path-params)
                           :values body})
   (res/response {:message "successfully updated user"}))
+
+(def patch-parameters {:path [:map [:id {:title "id"
+                                         :description "user id"} :int]]
+                       :body [:map
+                              [:address {:optional true} :string]
+                              [:profile-image {:optional true} :string]
+                              [:email :string]
+                              [:firstname {:optional true} :string]
+                              [:lastname {:optional true} :string]
+                              [:type [:enum "creator" "distributor" "admin"]]
+                              [:email-verified {:optional true} :int]
+                              [:onboarded {:optional true} :int]
+                              [:mobile {:optional true} :string]]})
+
+(def patch-responses {200 {:body [:map
+                                  [:user
+                                   [:map
+                                    [:id :int]
+                                    [:address {:optional true} :string]
+                                    [:profile-image {:optional true} :string]
+                                    [:email :string]
+                                    [:firstname {:optional true} :string]
+                                    [:lastname {:optional true} :string]
+                                    [:type [:enum "creator" "distributor" "admin"]]
+                                    [:email-verified {:optional true} :int]
+                                    [:onboarded {:optional true} :int]
+                                    [:mobile {:optional true} :string]]]]}
+                      401 {:body [:map [:message :string]]}
+                      403 {:body [:map [:message :string]]}})
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -2,64 +2,66 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds path-params] :as _request}]
+(defn get
+  {:summary "get user by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "user id"} :int]]}
+   :responses {200 {:body [:map
+                           [:user
+                            [:map
+                             [:id :int]
+                             [:address {:optional true} :string]
+                             [:profile-image {:optional true} :string]
+                             [:email :string]
+                             [:firstname {:optional true} :string]
+                             [:lastname {:optional true} :string]
+                             [:type [:enum "creator" "distributor" "admin"]]
+                             [:email-verified {:optional true} :int]
+                             [:onboarded {:optional true} :int]
+                             [:mobile {:optional true} :string]]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
   (let [user (->> path-params
                   (services/user ds))]
     (res/response (assoc {} :user (dissoc user :password)))))
 
-(def get-parameters {:path [:map [:id {:title "id"
-                                       :description "user id"} :int]]})
+(defn patch
+  {:summary "update user by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "user id"} :int]]
+                :body [:map
+                       [:address {:optional true} :string]
+                       [:profile-image {:optional true} :string]
+                       [:email :string]
+                       [:firstname {:optional true} :string]
+                       [:lastname {:optional true} :string]
+                       [:type [:enum "creator" "distributor" "admin"]]
+                       [:email-verified {:optional true} :int]
+                       [:onboarded {:optional true} :int]
+                       [:mobile {:optional true} :string]]}
+   :responses {200 {:body [:map
+                           [:user
+                            [:map
+                             [:id :int]
+                             [:address {:optional true} :string]
+                             [:profile-image {:optional true} :string]
+                             [:email :string]
+                             [:firstname {:optional true} :string]
+                             [:lastname {:optional true} :string]
+                             [:type [:enum "creator" "distributor" "admin"]]
+                             [:email-verified {:optional true} :int]
+                             [:onboarded {:optional true} :int]
+                             [:mobile {:optional true} :string]]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
 
-(def get-responses {200 {:body [:map
-                                [:user
-                                 [:map
-                                  [:id :int]
-                                  [:address {:optional true} :string]
-                                  [:profile-image {:optional true} :string]
-                                  [:email :string]
-                                  [:firstname {:optional true} :string]
-                                  [:lastname {:optional true} :string]
-                                  [:type [:enum "creator" "distributor" "admin"]]
-                                  [:email-verified {:optional true} :int]
-                                  [:onboarded {:optional true} :int]
-                                  [:mobile {:optional true} :string]]]]}
-                    401 {:body [:map [:message :string]]}
-                    403 {:body [:map [:message :string]]}})
-
-(defn patch [{:keys [ds body path-params] :as _request}]
+  [{:keys [ds body path-params] :as _request}]
   (services/update-user! ds
                          {:id (:id path-params)
                           :values body})
   (res/response {:message "successfully updated user"}))
-
-(def patch-parameters {:path [:map [:id {:title "id"
-                                         :description "user id"} :int]]
-                       :body [:map
-                              [:address {:optional true} :string]
-                              [:profile-image {:optional true} :string]
-                              [:email :string]
-                              [:firstname {:optional true} :string]
-                              [:lastname {:optional true} :string]
-                              [:type [:enum "creator" "distributor" "admin"]]
-                              [:email-verified {:optional true} :int]
-                              [:onboarded {:optional true} :int]
-                              [:mobile {:optional true} :string]]})
-
-(def patch-responses {200 {:body [:map
-                                  [:user
-                                   [:map
-                                    [:id :int]
-                                    [:address {:optional true} :string]
-                                    [:profile-image {:optional true} :string]
-                                    [:email :string]
-                                    [:firstname {:optional true} :string]
-                                    [:lastname {:optional true} :string]
-                                    [:type [:enum "creator" "distributor" "admin"]]
-                                    [:email-verified {:optional true} :int]
-                                    [:onboarded {:optional true} :int]
-                                    [:mobile {:optional true} :string]]]]}
-                      401 {:body [:map [:message :string]]}
-                      403 {:body [:map [:message :string]]}})
 
 (comment
   (require '[source.db.interface :as db])
@@ -68,4 +70,6 @@
           :path-params {:id 5}
           :body {:firstname "kiigan"
                  :lastname "korinzu"}})
+
+  (meta #'get)
   ())

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -25,7 +25,9 @@
   [{:keys [ds path-params] :as _request}]
   (let [user (->> path-params
                   (services/user ds))]
-    (res/response (assoc {} :user (dissoc user :password)))))
+    (->> (dissoc user :password)
+         (assoc {} :user)
+         (res/response))))
 
 (defn patch
   {:summary "update user by id"

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -3,10 +3,9 @@
             [ring.util.response :as res]))
 
 (defn get [{:keys [ds path-params] :as _request}]
-  (->> path-params
-       (services/user ds)
-       (assoc {} :user)
-       (res/response)))
+  (let [user (->> path-params
+                  (services/user ds))]
+    (res/response (assoc {} :user (dissoc user :password)))))
 
 (defn patch [{:keys [ds body path-params] :as _request}]
   (services/update-user! ds

--- a/src/source/routes/users.clj
+++ b/src/source/routes/users.clj
@@ -5,6 +5,23 @@
 (defn get [{:keys [ds] :as _request}]
   (res/response {:users (users/users ds)}))
 
+(def get-responses {200 {:body [:map
+                                    [:users
+                                     [:vector
+                                      [:map
+                                       [:id :int]
+                                       [:address {:optional true} :string]
+                                       [:profile-image {:optional true} :string]
+                                       [:email :string]
+                                       [:firstname {:optional true} :string]
+                                       [:lastname {:optional true} :string]
+                                       [:type [:enum "creator" "distributor" "admin"]]
+                                       [:email-verified {:optional true} :int]
+                                       [:onboarded {:optional true} :int]
+                                       [:mobile {:optional true} :string]]]]]}
+                        401 {:body [:map [:message :string]]}
+                        403 {:body [:map [:message :string]]}})
+
 (comment
   (require '[source.db.interface :as db])
   (get {:ds (db/ds :master)})

--- a/src/source/routes/users.clj
+++ b/src/source/routes/users.clj
@@ -2,25 +2,27 @@
   (:require [ring.util.response :as res]
             [source.services.users :as users]))
 
-(defn get [{:keys [ds] :as _request}]
-  (res/response {:users (users/users ds)}))
+(defn get
+  {:summary "get all users"
+   :responses  {200 {:body [:map
+                            [:users
+                             [:vector
+                              [:map
+                               [:id :int]
+                               [:address {:optional true} :string]
+                               [:profile-image {:optional true} :string]
+                               [:email :string]
+                               [:firstname {:optional true} :string]
+                               [:lastname {:optional true} :string]
+                               [:type [:enum "creator" "distributor" "admin"]]
+                               [:email-verified {:optional true} :int]
+                               [:onboarded {:optional true} :int]
+                               [:mobile {:optional true} :string]]]]]}
+                401 {:body [:map [:message :string]]}
+                403 {:body [:map [:message :string]]}}}
 
-(def get-responses {200 {:body [:map
-                                    [:users
-                                     [:vector
-                                      [:map
-                                       [:id :int]
-                                       [:address {:optional true} :string]
-                                       [:profile-image {:optional true} :string]
-                                       [:email :string]
-                                       [:firstname {:optional true} :string]
-                                       [:lastname {:optional true} :string]
-                                       [:type [:enum "creator" "distributor" "admin"]]
-                                       [:email-verified {:optional true} :int]
-                                       [:onboarded {:optional true} :int]
-                                       [:mobile {:optional true} :string]]]]]}
-                        401 {:body [:map [:message :string]]}
-                        403 {:body [:map [:message :string]]}})
+  [{:keys [ds] :as _request}]
+  (res/response {:users (users/users ds)}))
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/util.clj
+++ b/src/source/util.clj
@@ -1,6 +1,7 @@
 (ns source.util
   (:require [buddy.core.codecs :as codecs]
-            [buddy.core.nonce :as nonce]))
+            [buddy.core.nonce :as nonce]
+            [clojure.main :refer [demunge]]))
 
 (defn content-type [request]
   (or (get-in request [:headers "Content-Type"])
@@ -25,3 +26,12 @@
   (->
    (nonce/random-bytes 8)
    (codecs/bytes->hex)))
+
+(defn metadata [func]
+  (-> (class func)
+      (print-str)
+      (demunge)
+      (symbol)
+      (find-var)
+      (meta)))
+


### PR DESCRIPTION
Implemented swagger documentation for reitit routes. Each route currently has a summary and malli schemas for its parameters and responses. There are swagger groups for each endpoint domain. The 2 google routes currently don't have documentation. 