### PR TITLE
congest integration

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,7 @@
         ring/ring-json {:mvn/version "0.5.1"}
         ring/ring-defaults {:mvn/version "0.6.0"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
+        io.github.modulr-software/congest {:mvn/version "0.1.5"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.994"}
         org.xerial/sqlite-jdbc {:mvn/version "3.49.1.0"}
         buddy/buddy-core {:mvn/version "1.12.0-430"}
@@ -30,7 +31,7 @@
         io.replikativ/datahike {:mvn/version "0.6.1599"}
         hickory/hickory {:mvn/version "0.7.1"}
         metosin/jsonista {:mvn/version "0.3.13"}
-        metosin/reitit {:mvn/version "0.9.1"}
+        metosin/reitit {:mvn/version "0.9.1"} 
         metosin/reitit-middleware {:mvn/version "0.9.1"}
         metosin/reitit-swagger {:mvn/version "0.9.1"}
         metosin/reitit-swagger-ui {:mvn/version "0.9.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
         ring/ring-json {:mvn/version "0.5.1"}
         ring/ring-defaults {:mvn/version "0.6.0"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
-        io.github.modulr-software/congest {:mvn/version "0.1.5"}
+        io.github.modulr-software/congest {:mvn/version "0.1.6"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.994"}
         org.xerial/sqlite-jdbc {:mvn/version "3.49.1.0"}
         buddy/buddy-core {:mvn/version "1.12.0-430"}

--- a/src/source/datastore/interface.clj
+++ b/src/source/datastore/interface.clj
@@ -17,9 +17,6 @@
 (defn lookup [ds {:keys [_key _value] :as opts}]
   (dh/lookup ds opts))
 
-(defn exists? [ds k]
-  (dh/exists? ds k))
-
 (defn insert! [ds data]
   (dh/insert! ds data))
 

--- a/src/source/db/interface.clj
+++ b/src/source/db/interface.clj
@@ -11,7 +11,7 @@
 (defn execute! [ds opts]
   (hon/execute! ds opts))
 
-(defn find [ds opts]
+(defn find [ds {:keys [_tname _where _ret] :as opts}]
   (hon/find ds opts))
 
 (defn find-one [ds opts]

--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -157,6 +157,7 @@
   (tables/create-table-sql
    :jobs
    (tables/table-id)
+   [:job-id :text :not nil]
    [:status :text [:check [:in :status ["running" "stopped"]]]]
    [:args :text]
    [:handler :text :not nil]

--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -133,10 +133,51 @@
   (tables/create-table-sql
    :selection-schemas
    (tables/table-id)
-   [:version :integer :not nil]
    [:output-schema-id :integer :not nil]
    [:provider-id :integer :not nil]
    (tables/foreign-key :provider-id :providers :id)))
+
+(def incoming-posts
+  (tables/create-table-sql
+   :incoming-posts
+   (tables/table-id)
+   [:feed-id :integer :not nil]
+   [:title :text :not nil]
+   [:info :text]
+   [:url :text]
+   [:stream-url :text]
+   [:creator-id :integer :not nil]
+   [:season :integer]
+   [:episode :integer]
+   [:content-type-id :integer :not nil]
+   [:redacted :integer]
+   [:posted-at :datetime]))
+
+(def jobs
+  (tables/create-table-sql
+   :jobs
+   (tables/table-id)
+   [:status :text [:check [:in :status ["running" "stopped"]]]]
+   [:args :text]
+   [:handler :text :not nil]
+   [:last-heartbeat :datetime]
+   [:job-metadata-id :integer :not nil]
+   (tables/foreign-key :job-metadata-id :job-metadata :id)
+   [[:foreign-key :job-metadata-id] [:references :job-metadata :id] :on-delete :cascade]))
+
+(def job-metadata
+  (tables/create-table-sql
+   :job-metadata
+   (tables/table-id)
+   [:initial-delay :integer]
+   [:auto-start :integer]
+   [:stop-after-fail :integer]
+   [:kill-after :integer]
+   [:num-calls :integer]
+   [:interval :integer]
+   [:recurring :integer]
+   [:created-at :datetime]
+   [:sleep :integer]))
 
 (comment
   (require '[honey.sql :as sql])
@@ -155,4 +196,7 @@
   (sql/format user-sectors)
   (sql/format feed-sectors)
   (sql/format selection-schemas)
+  (sql/format incoming-posts)
+  (sql/format jobs)
+  (sql/format job-metadata)
   ())

--- a/src/source/jobs/core.clj
+++ b/src/source/jobs/core.clj
@@ -63,7 +63,7 @@
                 :sleep false})
 
   (services/jobs ds)
-  (services/job-metadata ds {:id 4})
+  (services/job-metadata ds {:id 5})
 
   (services/delete-job! ds {})
   (services/delete-job-metadata! ds {})

--- a/src/source/jobs/core.clj
+++ b/src/source/jobs/core.clj
@@ -1,0 +1,98 @@
+(ns source.jobs.core
+  (:require [congest.jobs :as congest]
+            [clojure.data.json :as json]
+            [source.services.interface :as services]
+            [source.jobs.oplog :as oplog]
+            [source.jobs.handlers :as handlers]))
+
+(defn start! [js ds store job-id]
+  (let [i->b (fn [i] (if (= i 1) true false))
+        job (services/job ds {:id job-id})
+        job-metadata (services/job-metadata ds {:id (:job-metadata-id job)})
+        metadata (-> (assoc job-metadata
+                            :id (str (:id job))
+                            :auto-start (i->b (:auto-start job-metadata))
+                            :stop-after-fail (i->b (:stop-after-fail job-metadata))
+                            :recurring? (i->b (:recurring job-metadata))
+                            :sleep (i->b (:sleep job-metadata))
+                            :args (json/read-str (:args job) {:key-fn keyword})
+                            :handler-name (:handler job)
+                            :handler (handlers/handler job)
+                            :logger oplog/operation-logger
+                            :ds ds
+                            :store store)
+                     (dissoc :recurring))]
+    (congest/deregister! js (str (:id job)))
+    (congest/register! js metadata)))
+
+(defn register!
+  "Registers a new job with the given job metadata, handler and arguments"
+  [js ds store job-metadata args]
+  (let [handler-fn (handlers/handler job-metadata)
+        job-id (-> (services/jobs ds)
+                   (count)
+                   (inc))
+        job-metadata (assoc job-metadata
+                            :id (str job-id)
+                            :args args
+                            :ds ds
+                            :store store
+                            :handler-name (:handler job-metadata)
+                            :handler handler-fn
+                            :logger oplog/operation-logger)]
+    (congest/register! js job-metadata)))
+
+(defn deregister! [js job-id]
+  (congest/deregister! js (str job-id)))
+
+(defn stop!
+  ([js job-id]
+   (stop! js job-id false))
+  ([js job-id kill?]
+   (congest/stop! js (str job-id) kill?)))
+
+(defn kill! [js job-id]
+  (stop! js job-id true))
+
+(defn kill-all! [js]
+  (congest/kill! js))
+
+(defn start-interrupted-jobs!
+  "Starts all jobs with a status of 'running'. Intended for server startup to restart interrupted jobs."
+  [js ds store]
+  (let [jobs (services/jobs ds)]
+    (run! (fn [job]
+            (when (= (:status job) "running")
+              (start! js ds store (:id job)))) jobs)))
+
+(comment
+  (require '[source.db.util :as db.util]
+           '[source.datastore.util :as store.util])
+  (def ds (db.util/conn))
+  (def store (store.util/conn :datahike))
+
+  (def testjob {:initial-delay 10
+                :auto-start true
+                :stop-after-fail false,
+                ;:kill-after 5
+                ;:num-calls nil
+                :interval 3000
+                :recurring? true
+                :handler :test
+                :created-at nil
+                :sleep false})
+
+  (services/jobs ds)
+  (services/job-metadata ds {:id 3})
+
+  (services/delete-job! ds {})
+  (services/delete-job-metadata! ds {})
+
+  (def js (congest/create-job-service []))
+  (register! js ds store testjob {:name "congest"})
+  (deregister! js 1)
+  (stop! js 1)
+  (start! js ds store 1)
+  (start-interrupted-jobs! js ds store)
+
+  ())

--- a/src/source/jobs/core.clj
+++ b/src/source/jobs/core.clj
@@ -5,94 +5,74 @@
             [source.jobs.oplog :as oplog]
             [source.jobs.handlers :as handlers]))
 
-(defn start! [js ds store job-id]
-  (let [i->b (fn [i] (if (= i 1) true false))
-        job (services/job ds {:id job-id})
-        job-metadata (services/job-metadata ds {:id (:job-metadata-id job)})
-        metadata (-> (assoc job-metadata
-                            :id (str (:id job))
-                            :auto-start (i->b (:auto-start job-metadata))
-                            :stop-after-fail (i->b (:stop-after-fail job-metadata))
-                            :recurring? (i->b (:recurring job-metadata))
-                            :sleep (i->b (:sleep job-metadata))
-                            :args (json/read-str (:args job) {:key-fn keyword})
-                            :handler-name (:handler job)
-                            :handler (handlers/handler job)
-                            :logger oplog/operation-logger
-                            :ds ds
-                            :store store)
-                     (dissoc :recurring))]
-    (congest/deregister! js (str (:id job)))
-    (congest/register! js metadata)))
+(defn prepare-congest-metadata
+  "given raw job metadata, returns extended metadata necessary for use with congest"
+  [ds store metadata]
+  (let [i->b (fn [i] (if (integer? i)
+                       (if (= i 1) true false)
+                       i))
+        args (:args metadata)]
+    (-> metadata
+        (assoc :auto-start (i->b (:auto-start metadata))
+               :stop-after-fail (i->b (:stop-after-fail metadata))
+               :recurring? (i->b (or (:recurring metadata) (:recurring? metadata)))
+               :sleep (i->b (:sleep metadata))
+               :args (if (string? args) (json/read-str (:args metadata) {:key-fn keyword}) args)
+               :handler-name (:handler metadata)
+               :handler (handlers/handler metadata)
+               :logger oplog/operation-logger
+               :ds ds
+               :store store)
+        (dissoc :recurring))))
 
-(defn register!
-  "Registers a new job with the given job metadata, handler and arguments"
-  [js ds store job-metadata args]
-  (let [handler-fn (handlers/handler job-metadata)
-        job-id (-> (services/jobs ds)
-                   (count)
-                   (inc))
-        job-metadata (assoc job-metadata
-                            :id (str job-id)
+(defn start!
+  "given a job-id, re-registers an existing job from the database"
+  [js ds store job-id]
+  (let [{:keys [job-metadata-id args handler]} (services/job ds {:where [:= :job-id job-id]})
+        metadata (-> (services/job-metadata ds {:id job-metadata-id})
+                     (assoc :id job-id
                             :args args
-                            :ds ds
-                            :store store
-                            :handler-name (:handler job-metadata)
-                            :handler handler-fn
-                            :logger oplog/operation-logger)]
-    (congest/register! js job-metadata)))
-
-(defn deregister! [js job-id]
-  (congest/deregister! js (str job-id)))
-
-(defn stop!
-  ([js job-id]
-   (stop! js job-id false))
-  ([js job-id kill?]
-   (congest/stop! js (str job-id) kill?)))
-
-(defn kill! [js job-id]
-  (stop! js job-id true))
-
-(defn kill-all! [js]
-  (congest/kill! js))
+                            :handler handler))]
+    (congest/deregister! js job-id)
+    (congest/register! js (prepare-congest-metadata ds store metadata))))
 
 (defn start-interrupted-jobs!
   "Starts all jobs with a status of 'running'. Intended for server startup to restart interrupted jobs."
   [js ds store]
   (let [jobs (services/jobs ds)]
-    (run! (fn [job]
-            (when (= (:status job) "running")
-              (start! js ds store (:id job)))) jobs)))
+    (run! (fn [{:keys [job-id status]}]
+            (when (= status "running")
+              (start! js ds store job-id))) jobs)))
 
 (comment
   (require '[source.db.util :as db.util]
            '[source.datastore.util :as store.util])
+
   (def ds (db.util/conn))
   (def store (store.util/conn :datahike))
 
-  (def testjob {:initial-delay 10
+  (def testjob {:id "test"
+                :initial-delay 10
                 :auto-start true
                 :stop-after-fail false,
-                ;:kill-after 5
-                ;:num-calls nil
                 :interval 3000
                 :recurring? true
+                :args {:name "congest"}
                 :handler :test
                 :created-at nil
                 :sleep false})
 
   (services/jobs ds)
-  (services/job-metadata ds {:id 3})
+  (services/job-metadata ds {:id 4})
 
   (services/delete-job! ds {})
   (services/delete-job-metadata! ds {})
 
   (def js (congest/create-job-service []))
-  (register! js ds store testjob {:name "congest"})
-  (deregister! js 1)
-  (stop! js 1)
-  (start! js ds store 1)
+  (congest/register! js (prepare-congest-metadata ds store testjob))
+  (congest/deregister! js "test")
+  (congest/stop! js "test" false)
+  (start! js ds store "test")
   (start-interrupted-jobs! js ds store)
 
   ())

--- a/src/source/jobs/core.clj
+++ b/src/source/jobs/core.clj
@@ -36,13 +36,17 @@
     (congest/deregister! js job-id)
     (congest/register! js (prepare-congest-metadata ds store metadata))))
 
-(defn start-interrupted-jobs!
-  "Starts all jobs with a status of 'running'. Intended for server startup to restart interrupted jobs."
-  [js ds store]
+(defn interrupted-jobs
+  "Get congest-ready metadata of all jobs marked as running"
+  [ds store]
   (let [jobs (services/jobs ds)]
-    (run! (fn [{:keys [job-id status]}]
-            (when (= status "running")
-              (start! js ds store job-id))) jobs)))
+    (reduce (fn [acc {:keys [job-id job-metadata-id args handler status]}]
+              (when (= status "running")
+                (let [metadata (-> (services/job-metadata ds {:id job-metadata-id})
+                                   (assoc :id job-id
+                                          :args args
+                                          :handler handler))]
+                  (conj acc (prepare-congest-metadata ds store metadata))))) [] jobs)))
 
 (comment
   (require '[source.db.util :as db.util]
@@ -73,6 +77,6 @@
   (congest/deregister! js "test")
   (congest/stop! js "test" false)
   (start! js ds store "test")
-  (start-interrupted-jobs! js ds store)
+  (interrupted-jobs ds store)
 
   ())

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -1,0 +1,28 @@
+(ns source.jobs.handlers
+  (:require [source.services.interface :as services]
+            [source.util :as util]))
+
+(defmulti handler
+  (fn [opts]
+    (keyword (:handler opts))))
+
+(defmethod handler :default [opts]
+  (throw (IllegalArgumentException.
+          (str "Handler with name " (:handler opts) " does not exist."))))
+
+(defmethod handler :test [_]
+  (fn [{:keys [args]}]
+    (println "hello" (get args :name) args)))
+
+(defmethod handler :update-feed-post [_]
+  (fn [{:keys [args ds store]}]
+    (try
+      (let [{:keys [feed-id post-id schema-id url]} args
+            extracted (services/extract-data store {:schema-id schema-id
+                                                    :url url})]
+        (services/update-feed! ds {:id feed-id
+                                   :data {:updated-at (util/get-utc-timestamp-string)}})
+        (services/update-incoming-post! ds {:id post-id
+                                            :data extracted}))
+      (catch Exception _ :fail))))
+

--- a/src/source/jobs/oplog.clj
+++ b/src/source/jobs/oplog.clj
@@ -3,22 +3,30 @@
             [source.util :as util]
             [clojure.data.json :as json]))
 
-(defn delete-job! [{:keys [ds id]}]
-  (let [metadata-id (:job-metadata-id (services/job ds {:id id}))]
-    (services/delete-job-metadata! ds {:id metadata-id})
+(defn delete-job!
+  "Delete job record and metadata associated therewith"
+  [{:keys [ds id]}]
+  (let [{:keys [job-metadata-id id]} (services/job ds {:where [:= :job-id id]})]
+    (services/delete-job-metadata! ds {:id job-metadata-id})
     (services/delete-job! ds {:id id})))
 
-(defn update-job! [{:keys [ds id]} status]
-  (services/update-job! ds {:id id
+(defn update-job!
+  "Update job status and last heartbeat"
+  [{:keys [ds id]} status]
+  (services/update-job! ds {:where [:= :job-id id]
                             :data {:status status
                                    :last-heartbeat (util/get-utc-timestamp-string)}}))
 
-(defn update-job-metadata! [{:keys [ds id num-calls]}]
-  (let [metadata-id (:job-metadata-id (services/job ds {:id id}))]
+(defn update-job-metadata!
+  "Update the number of calls in job metadata"
+  [{:keys [ds id num-calls]}]
+  (let [metadata-id (:job-metadata-id (services/job ds {:where [:= :job-id id]}))]
     (services/update-job-metadata! ds {:id metadata-id
                                        :data {:num-calls num-calls}})))
 
-(defn create-job! [{:keys [ds id args handler-name] :as job-metadata}]
+(defn create-job!
+  "Inserts a new job record and its associated metadata if the job doesn't already exist in the database."
+  [{:keys [ds id args handler-name] :as job-metadata}]
   (let [b->i (fn [b] (if b 1 0))
         metadata {:initial-delay (:initial-delay job-metadata)
                   :auto-start (b->i (:auto-start job-metadata))
@@ -29,15 +37,15 @@
                   :recurring (b->i (:recurring? job-metadata))
                   :created-at (:created-at job-metadata)
                   :sleep (b->i (:sleep job-metadata))}
-        job (services/job ds {:id id})
+        job (services/job ds {:where [:= :job-id id]})
         metadata-id (when-not (some? job)
                       (:id (services/insert-job-metadata! ds {:data metadata
                                                               :ret :1})))]
     (if (some? job)
-      (services/update-job! ds {:id id
+      (services/update-job! ds {:where [:= :job-id id]
                                 :data {:status "running"
                                        :last-heartbeat (util/get-utc-timestamp-string)}})
-      (services/insert-job! ds {:data {:id id
+      (services/insert-job! ds {:data {:job-id id
                                        :status "running"
                                        :args (json/json-str args)
                                        :handler (name handler-name)
@@ -45,7 +53,9 @@
                                        :job-metadata-id metadata-id}
                                 :ret :1}))))
 
-(defn operation-logger [{:keys [action] :as metadata}]
+(defn operation-logger
+  "This function serves as the operation logger called from within congest to handle the persistence layer"
+  [{:keys [action] :as metadata}]
   (cond
     (= action "register")
     (create-job! metadata)

--- a/src/source/jobs/oplog.clj
+++ b/src/source/jobs/oplog.clj
@@ -1,0 +1,65 @@
+(ns source.jobs.oplog
+  (:require [source.services.interface :as services]
+            [source.util :as util]
+            [clojure.data.json :as json]))
+
+(defn delete-job! [{:keys [ds id]}]
+  (let [metadata-id (:job-metadata-id (services/job ds {:id id}))]
+    (services/delete-job-metadata! ds {:id metadata-id})
+    (services/delete-job! ds {:id id})))
+
+(defn update-job! [{:keys [ds id]} status]
+  (services/update-job! ds {:id id
+                            :data {:status status
+                                   :last-heartbeat (util/get-utc-timestamp-string)}}))
+
+(defn update-job-metadata! [{:keys [ds id num-calls]}]
+  (let [metadata-id (:job-metadata-id (services/job ds {:id id}))]
+    (services/update-job-metadata! ds {:id metadata-id
+                                       :data {:num-calls num-calls}})))
+
+(defn create-job! [{:keys [ds id args handler-name] :as job-metadata}]
+  (let [b->i (fn [b] (if b 1 0))
+        metadata {:initial-delay (:initial-delay job-metadata)
+                  :auto-start (b->i (:auto-start job-metadata))
+                  :stop-after-fail (b->i (:stop-after-fail job-metadata))
+                  :kill-after (:kill-after job-metadata)
+                  :num-calls (:num-calls job-metadata)
+                  :interval (:interval job-metadata)
+                  :recurring (b->i (:recurring? job-metadata))
+                  :created-at (:created-at job-metadata)
+                  :sleep (b->i (:sleep job-metadata))}
+        job (services/job ds {:id id})
+        metadata-id (when-not (some? job)
+                      (:id (services/insert-job-metadata! ds {:data metadata
+                                                              :ret :1})))]
+    (if (some? job)
+      (services/update-job! ds {:id id
+                                :data {:status "running"
+                                       :last-heartbeat (util/get-utc-timestamp-string)}})
+      (services/insert-job! ds {:data {:id id
+                                       :status "running"
+                                       :args (json/json-str args)
+                                       :handler (name handler-name)
+                                       :last-heartbeat (util/get-utc-timestamp-string)
+                                       :job-metadata-id metadata-id}
+                                :ret :1}))))
+
+(defn operation-logger [{:keys [action] :as metadata}]
+  (cond
+    (= action "register")
+    (create-job! metadata)
+
+    (= action "deregister")
+    (delete-job! metadata)
+
+    (= action "start")
+    (update-job! metadata "running")
+
+    (or (= action "stop") (= action "kill"))
+    (update-job! metadata "stopped")
+
+    (= action "run")
+    (do
+      (update-job! metadata "running")
+      (update-job-metadata! metadata))))

--- a/src/source/middleware/core.clj
+++ b/src/source/middleware/core.clj
@@ -23,7 +23,9 @@
         (assoc :store store)
         (handler))))
 
-(defn wrap-js [handler js]
+(defn wrap-js 
+  "attaches the provided job service to the handler's request"
+  [handler js]
   (fn [request]
     (-> request
         (assoc :js js)
@@ -37,7 +39,9 @@
   (-> app
       (wrap-store store)))
 
-(defn apply-js [app js]
+(defn apply-js 
+  "middleware for attaching the job service to the request"
+  [app js]
   (-> app
       (wrap-js js)))
 

--- a/src/source/middleware/core.clj
+++ b/src/source/middleware/core.clj
@@ -4,6 +4,7 @@
             [source.config :as conf]
             [camel-snake-kebab.core :as csk]
             [camel-snake-kebab.extras :as cske]
+            [ring.util.response :as res]
             [ring.middleware.cors :refer [wrap-cors]]
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.defaults :refer [wrap-defaults site-defaults]]
@@ -22,9 +23,32 @@
         (assoc :store store)
         (handler))))
 
+(defn wrap-js [handler js]
+  (fn [request]
+    (-> request
+        (assoc :js js)
+        (handler))))
+
+(defn apply-ds [app ds]
+  (-> app
+      (wrap-ds ds)))
+
 (defn apply-store [app store]
   (-> app
       (wrap-store store)))
+
+(defn apply-js [app js]
+  (-> app
+      (wrap-js js)))
+
+(defn wrap-exception-logger [handler]
+  (fn [req]
+    (try
+      (handler req)
+      (catch Exception e
+        (println "Unhandled Exception:\n" e)
+        (-> (res/response {:message "Internal Server Error"})
+            (res/status 500))))))
 
 (defn process-body [{:keys [body] :as req} t-fn]
   (assoc req
@@ -44,14 +68,12 @@
         (handler)
         (process-body csk/->camelCaseKeyword))))
 
-(defn apply-ds [app ds]
+(defn apply-generic [app & {:keys [ds store js]}]
   (-> app
-      (wrap-ds ds)))
-
-(defn apply-generic [app & {:keys [ds store]}]
-  (-> app
+      (wrap-exception-logger)
       (apply-ds ds)
       (apply-store store)
+      (apply-js js)
       (wrap-case-conversion)
       (content-type/wrap-content-type)
       (wrap-cors :access-control-allow-origin [(re-pattern (conf/read-value :cors-origin))]
@@ -70,4 +92,3 @@
 (defn apply-bundle [app]
   (-> app
       (auth/wrap-bundle-id)))
-

--- a/src/source/middleware/interface.clj
+++ b/src/source/middleware/interface.clj
@@ -1,8 +1,8 @@
 (ns source.middleware.interface
   (:require [source.middleware.core :as mw]))
 
-(defn apply-generic [app & {:keys [ds store]}]
-  (mw/apply-generic app :ds ds :store store))
+(defn apply-generic [app & {:keys [ds store js]}]
+  (mw/apply-generic app :ds ds :store store :js js))
 
 (defn apply-auth
   "accepts required-type as an optional parameter to authorize the route only for the specified user type"
@@ -11,4 +11,3 @@
 
 (defn apply-bundle [app]
   (mw/apply-bundle app))
-

--- a/src/source/migrations/001_init_master_db.clj
+++ b/src/source/migrations/001_init_master_db.clj
@@ -77,7 +77,10 @@
       :businesses
       :user-sectors
       :feed-sectors
-      :selection-schemas])
+      :selection-schemas
+      :incoming-posts
+      :jobs
+      :job-metadata])
 
     (db/insert! ds-master baselines-seed)
     (db/insert! ds-master cadences-seed)

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -1,0 +1,120 @@
+(ns source.routes.feeds
+  (:require [source.services.interface :as services]
+            [source.util :as utils]
+            [source.jobs.core :as jobs]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get all feeds"
+   :responses  {200 {:body [:map
+                            [:users
+                             [:vector
+                              [:map
+                               [:id :int]
+                               [:title :string]
+                               [:display-picture [:maybe :string]]
+                               [:url [:maybe :string]]
+                               [:rss-url :string]
+                               [:user-id [:maybe :int]]
+                               [:provider-id [:maybe :int]]
+                               [:created-at :string]
+                               [:updated-at [:maybe :string]]
+                               [:content-type-id :int]
+                               [:cadence-id :int]
+                               [:baseline-id :int]
+                               [:ts-and-cs [:maybe :string]]
+                               [:state [:maybe :string]]]]]]}}}
+
+  [{:keys [ds user] :as _request}]
+  (-> (services/feeds ds {:where [:= :user-id (:id user)]})
+      (res/response)))
+
+(defn post
+  {:summary "adds a feed and extracts data from RSS feed URL into a post and schedules a job to keep them updated"
+   :parameters {:body [:map
+                       [:title :string]
+                       [:display-picture {:optional true} :string]
+                       [:url {:optional true} :string]
+                       [:rss-url :string]
+                       [:provider-id :int]
+                       [:content-type-id :int]
+                       [:cadence-id :int]
+                       [:baseline-id :int]
+                       [:ts-and-cs {:optional true} :string]
+                       [:state {:optional true} :string]]}
+   :responses {200 {:body [:map
+                           [:id :int]
+                           [:title :string]
+                           [:display-picture [:maybe :string]]
+                           [:url [:maybe :string]]
+                           [:rss-url :string]
+                           [:user-id [:maybe :int]]
+                           [:provider-id [:maybe :int]]
+                           [:created-at :string]
+                           [:updated-at [:maybe :string]]
+                           [:content-type-id :int]
+                           [:cadence-id :int]
+                           [:baseline-id :int]
+                           [:ts-and-cs [:maybe :string]]
+                           [:state [:maybe :string]]]}}}
+
+  [{:keys [js ds store user body] :as _request}]
+  (let [{:keys [provider-id rss-url content-type-id]} body
+        datetime (utils/get-utc-timestamp-string)
+        selection-schemas (->> [:= :provider-id provider-id]
+                               (assoc {} :where)
+                               (services/selection-schemas ds))
+        latest-ss (->> selection-schemas
+                       (reduce (fn [acc {:keys [id]}]
+                                 (conj acc id)) [])
+                       (apply max -1))
+        extracted (when-not (= latest-ss -1)
+                    (services/extract-data store {:schema-id latest-ss
+                                                  :url rss-url}))
+        new-feed (services/insert-feed!
+                  ds
+                  {:data (merge body {:user-id (:id user)
+                                      :created-at datetime})})
+        new-post (when (some? extracted)
+                   (services/insert-incoming-post! ds {:data (merge extracted
+                                                                    {:feed-id (:id new-feed)
+                                                                     :creator-id (:id user)
+                                                                     :content-type-id content-type-id})}))]
+
+    (if (some? extracted)
+      (do (jobs/register! js ds store
+                          {:initial-delay 10;(* 1000 60 60 24)
+                           :auto-start true
+                           :stop-after-fail false,
+                           :interval (* 1000 60) ;(* 1000 60 60 24)
+                           :recurring? true
+                           :handler :update-feed-post
+                           :created-at (utils/get-utc-timestamp-string)
+                           :sleep false}
+                          {:feed-id (:id new-feed)
+                           :post-id (:id new-post)
+                           :schema-id latest-ss
+                           :url rss-url})
+          (res/response new-feed))
+
+      (-> (res/response {:message "Failed to extract data, did you provide a selection schema?"})
+          (res/status 500)))))
+
+(comment
+  (require '[source.db.util :as db.util]
+           '[source.datastore.util :as store.util]
+           '[congest.jobs :as js])
+
+  (get {:ds (db.util/conn) :user {:id 5}})
+  (post {:ds (db.util/conn)
+         :js (js/create-job-service [])
+         :store (store.util/conn :datahike)
+         :user {:id 5}
+         :body {:title "primeagen test"
+                :rss-url "https://www.youtube.com/feeds/videos.xml?channel_id=UCUyeluBRhGPCW4rPe_UvBZQ"
+                :provider-id 1
+                :content-type-id 1
+                :cadence-id 1
+                :baseline-id 1}})
+
+  ())

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -1,6 +1,7 @@
 (ns source.routes.feeds
   (:require [source.services.interface :as services]
             [source.util :as utils]
+            [congest.jobs :as congest]
             [source.jobs.core :as jobs]
             [ring.util.response :as res]))
 
@@ -82,32 +83,35 @@
                                                                      :content-type-id content-type-id})}))]
 
     (if (some? extracted)
-      (do (jobs/register! js ds store
-                          {:initial-delay (* 1000 60 60 24)
-                           :auto-start true
-                           :stop-after-fail false,
-                           :interval (* 1000 60 60 24)
-                           :recurring? true
-                           :handler :update-feed-post
-                           :created-at (utils/get-utc-timestamp-string)
-                           :sleep false}
-                          {:feed-id (:id new-feed)
-                           :post-id (:id new-post)
-                           :schema-id latest-ss
-                           :url rss-url})
-          (res/response new-feed))
+      (do
+        (->> (jobs/prepare-congest-metadata
+              ds
+              store
+              {:initial-delay (* 1000 60 60 24)
+               :auto-start true
+               :stop-after-fail false,
+               :interval (* 1000 60 60 24)
+               :recurring? true
+               :args {:feed-id (:id new-feed)
+                      :post-id (:id new-post)
+                      :schema-id latest-ss
+                      :url rss-url}
+               :handler :update-feed-post
+               :created-at (utils/get-utc-timestamp-string)
+               :sleep false})
+             (congest/register! js))
+        (res/response new-feed))
 
-      (-> (res/response {:message "Failed to extract data, did you provide a selection schema?"})
+      (-> (res/response {:message "failed to extract data"})
           (res/status 500)))))
 
 (comment
   (require '[source.db.util :as db.util]
-           '[source.datastore.util :as store.util]
-           '[congest.jobs :as js])
+           '[source.datastore.util :as store.util])
 
   (get {:ds (db.util/conn) :user {:id 5}})
   (post {:ds (db.util/conn)
-         :js (js/create-job-service [])
+         :js (congest/create-job-service [])
          :store (store.util/conn :datahike)
          :user {:id 5}
          :body {:title "primeagen test"
@@ -116,5 +120,4 @@
                 :content-type-id 1
                 :cadence-id 1
                 :baseline-id 1}})
-
   ())

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -80,14 +80,16 @@
                    (services/insert-incoming-post! ds {:data (merge extracted
                                                                     {:feed-id (:id new-feed)
                                                                      :creator-id (:id user)
-                                                                     :content-type-id content-type-id})}))]
+                                                                     :content-type-id content-type-id})}))
+        {:keys [email]} (services/user ds {:id (:id user)})]
 
     (if (some? extracted)
       (do
         (->> (jobs/prepare-congest-metadata
               ds
               store
-              {:initial-delay (* 1000 60 60 24)
+              {:id (str email "-" (:id new-feed) "-" (:id new-post))
+               :initial-delay (* 1000 60 60 24)
                :auto-start true
                :stop-after-fail false,
                :interval (* 1000 60 60 24)

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -83,10 +83,10 @@
 
     (if (some? extracted)
       (do (jobs/register! js ds store
-                          {:initial-delay 10;(* 1000 60 60 24)
+                          {:initial-delay (* 1000 60 60 24)
                            :auto-start true
                            :stop-after-fail false,
-                           :interval (* 1000 60) ;(* 1000 60 60 24)
+                           :interval (* 1000 60 60 24)
                            :recurring? true
                            :handler :update-feed-post
                            :created-at (utils/get-utc-timestamp-string)

--- a/src/source/routes/interface.clj
+++ b/src/source/routes/interface.clj
@@ -1,6 +1,6 @@
 (ns source.routes.interface
   (:require [source.routes.reitit :as reitit]))
 
-(defn create-app []
-  (reitit/create-app))
+(defn create-app [{:keys [ds store js] :as opts}]
+  (reitit/create-app opts))
 

--- a/src/source/routes/job.clj
+++ b/src/source/routes/job.clj
@@ -5,13 +5,15 @@
 (defn get [{:keys [ds path-params] :as _req}]
   (let [job (services/job ds path-params)
         metadata (services/job-metadata ds {:id (:job-metadata-id job)})]
-    (res/response (merge (dissoc job :job-metadata-id)
-                         {:metadata metadata}))))
+    (if (some? job)
+      (res/response (merge (dissoc job :job-metadata-id)
+                           {:metadata metadata}))
+      (res/response {}))))
 
 (comment
   (require '[source.db.util :as db.util])
   (def ds (db.util/conn))
 
-  (get {:ds ds :path-params {:id 1}})
+  (get {:ds ds :path-params {:id 5}})
 
   ())

--- a/src/source/routes/job.clj
+++ b/src/source/routes/job.clj
@@ -1,0 +1,17 @@
+(ns source.routes.job
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [ds path-params] :as _req}]
+  (let [job (services/job ds path-params)
+        metadata (services/job-metadata ds {:id (:job-metadata-id job)})]
+    (res/response (merge (dissoc job :job-metadata-id)
+                         {:metadata metadata}))))
+
+(comment
+  (require '[source.db.util :as db.util])
+  (def ds (db.util/conn))
+
+  (get {:ds ds :path-params {:id 1}})
+
+  ())

--- a/src/source/routes/job_deregister.clj
+++ b/src/source/routes/job_deregister.clj
@@ -1,7 +1,9 @@
 (ns source.routes.job-deregister
   (:require [congest.jobs :as jobs]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [source.services.interface :as services]))
 
-(defn get [{:keys [js path-params] :as _req}]
-  (jobs/deregister! js (:id path-params))
-  (res/response {:message "successfully deregistered job"}))
+(defn get [{:keys [js ds path-params] :as _req}]
+  (let [job (services/job ds path-params)]
+    (jobs/deregister! js (:job-id job))
+    (res/response {:message "successfully deregistered job"})))

--- a/src/source/routes/job_deregister.clj
+++ b/src/source/routes/job_deregister.clj
@@ -1,0 +1,7 @@
+(ns source.routes.job-deregister
+  (:require [source.jobs.core :as jobs]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [js path-params] :as _req}]
+  (jobs/deregister! js (:id path-params))
+  (res/response {:message "successfully deregistered job"}))

--- a/src/source/routes/job_deregister.clj
+++ b/src/source/routes/job_deregister.clj
@@ -1,5 +1,5 @@
 (ns source.routes.job-deregister
-  (:require [source.jobs.core :as jobs]
+  (:require [congest.jobs :as jobs]
             [ring.util.response :as res]))
 
 (defn get [{:keys [js path-params] :as _req}]

--- a/src/source/routes/job_start.clj
+++ b/src/source/routes/job_start.clj
@@ -1,7 +1,9 @@
 (ns source.routes.job-start
   (:require [source.jobs.core :as jobs]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [source.services.interface :as services]))
 
 (defn get [{:keys [js ds store path-params]}]
-  (jobs/start! js ds store (:id path-params))
-  (res/response {:message "successfully started job"}))
+  (let [job (services/job ds path-params)]
+    (jobs/start! js ds store (:job-id job))
+    (res/response {:message "successfully started job"})))

--- a/src/source/routes/job_start.clj
+++ b/src/source/routes/job_start.clj
@@ -1,0 +1,7 @@
+(ns source.routes.job-start
+  (:require [source.jobs.core :as jobs]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [js ds store path-params]}]
+  (jobs/start! js ds store (:id path-params))
+  (res/response {:message "successfully started job"}))

--- a/src/source/routes/job_stop.clj
+++ b/src/source/routes/job_stop.clj
@@ -1,7 +1,7 @@
 (ns source.routes.job-stop
-  (:require [source.jobs.core :as jobs]
+  (:require [congest.jobs :as jobs]
             [ring.util.response :as res]))
 
 (defn get [{:keys [js path-params]}]
-  (jobs/stop! js (:id path-params))
+  (jobs/stop! js (:id path-params) false)
   (res/response {:message "successfully stopped job"}))

--- a/src/source/routes/job_stop.clj
+++ b/src/source/routes/job_stop.clj
@@ -1,7 +1,9 @@
 (ns source.routes.job-stop
   (:require [congest.jobs :as jobs]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [source.services.interface :as services]))
 
-(defn get [{:keys [js path-params]}]
-  (jobs/stop! js (:id path-params) false)
-  (res/response {:message "successfully stopped job"}))
+(defn get [{:keys [js ds path-params]}]
+  (let [job (services/job ds path-params)]
+    (jobs/stop! js (:job-id job) false)
+    (res/response {:message "successfully stopped job"})))

--- a/src/source/routes/job_stop.clj
+++ b/src/source/routes/job_stop.clj
@@ -1,0 +1,7 @@
+(ns source.routes.job-stop
+  (:require [source.jobs.core :as jobs]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [js path-params]}]
+  (jobs/stop! js (:id path-params))
+  (res/response {:message "successfully stopped job"}))

--- a/src/source/routes/jobs.clj
+++ b/src/source/routes/jobs.clj
@@ -5,11 +5,13 @@
             [ring.util.response :as res]))
 
 (defn get [{:keys [ds] :as _req}]
-  (res/response
+  (->>
+   (services/jobs ds)
    (mapv (fn [job]
            (let [metadata (services/job-metadata ds {:id (:job-metadata-id job)})]
              (merge (dissoc job :job-metadata-id)
-                    {:metadata metadata}))) (services/jobs ds))))
+                    {:metadata metadata}))))
+   (res/response)))
 
 (defn post [{:keys [js ds store body] :as _req}]
   (let [{:keys [metadata]} body]

--- a/src/source/routes/jobs.clj
+++ b/src/source/routes/jobs.clj
@@ -1,5 +1,6 @@
 (ns source.routes.jobs
   (:require [source.services.interface :as services]
+            [congest.jobs :as congest]
             [source.jobs.core :as jobs]
             [ring.util.response :as res]))
 
@@ -11,6 +12,6 @@
                     {:metadata metadata}))) (services/jobs ds))))
 
 (defn post [{:keys [js ds store body] :as _req}]
-  (let [{:keys [metadata args]} body]
-    (jobs/register! js ds store metadata args)
+  (let [{:keys [metadata]} body]
+    (congest/register! js (jobs/prepare-congest-metadata ds store metadata))
     (res/response {:message "successfully registered job"})))

--- a/src/source/routes/jobs.clj
+++ b/src/source/routes/jobs.clj
@@ -1,0 +1,16 @@
+(ns source.routes.jobs
+  (:require [source.services.interface :as services]
+            [source.jobs.core :as jobs]
+            [ring.util.response :as res]))
+
+(defn get [{:keys [ds] :as _req}]
+  (res/response
+   (mapv (fn [job]
+           (let [metadata (services/job-metadata ds {:id (:job-metadata-id job)})]
+             (merge (dissoc job :job-metadata-id)
+                    {:metadata metadata}))) (services/jobs ds))))
+
+(defn post [{:keys [js ds store body] :as _req}]
+  (let [{:keys [metadata args]} body]
+    (jobs/register! js ds store metadata args)
+    (res/response {:message "successfully registered job"})))

--- a/src/source/routes/output_schemas.clj
+++ b/src/source/routes/output_schemas.clj
@@ -8,5 +8,5 @@
 
 (defn post [{:keys [store body] :as _request}]
   (let [{:keys [schema]} body]
-    (services/add-output-schema! store schema)
+    (services/insert-output-schema! store schema)
     (res/response {:message "successfully added output schema"})))

--- a/src/source/routes/provider.clj
+++ b/src/source/routes/provider.clj
@@ -2,12 +2,29 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds path-params] :as _request}]
+(defn get
+  {:summary "get provider by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "provider id"} :int]]}
+   :responses {200 {:body [:map
+                           [:id :int]
+                           [:name :string]
+                           [:domain :string]
+                           [:content-type-id :int]]}}}
+
+  [{:keys [ds path-params] :as _request}]
   (->> path-params
        (services/provider ds)
        (res/response)))
 
-(defn delete [{:keys [ds path-params] :as _request}]
+(defn delete 
+  {:summary "given a provider id, delete provider and associated selection schemas"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "provider id"} :int]]}
+   :responses {200 {:body [:map [:message :string]]}}}
+  
+  [{:keys [store ds path-params] :as _request}]
   (->> path-params
        (services/delete-provider! ds))
+  (services/delete-selection-schemas-by-provider! store ds (:id path-params))
   (res/response {:message "successfully deleted provider"}))

--- a/src/source/routes/providers.clj
+++ b/src/source/routes/providers.clj
@@ -2,18 +2,32 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds] :as _request}]
+(defn get
+  {:summary "get all providers"
+   :responses {200 {:body [:vector
+                           [:map
+                            [:id :int]
+                            [:name :string]
+                            [:domain :string]
+                            [:content-type-id :int]]]}}}
+
+  [{:keys [ds] :as _request}]
   (-> (services/providers ds)
       (res/response)))
 
-(defn post [{:keys [ds body] :as _request}]
+(defn post
+  {:summary "add a provider"
+   :parameters {:body [:map
+                       [:provider
+                        [:map
+                         [:id :int]
+                         [:name :string]
+                         [:domain :string]
+                         [:content-type-id :int]]]]}
+   :responses {200 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds body] :as _request}]
   (let [{:keys [provider]} body]
     (services/insert-provider! ds {:data provider
                                    :ret :1})
     (res/response {:message "successfully added provider"})))
-
-(comment
-  (require '[source.datastore.interface :as store])
-
-  (services/add-provider! (store/ds :datahike) "YouTube")
-  ())

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -145,7 +145,8 @@
          [""                      {:get jobs/get}]
          ["/manage"
           ["/register"            {:post jobs/post}]]
-         ["/:id"                  {:get job/get}
+         ["/:id"
+          [""                     {:get job/get}]
           ["/manage"
            ["/deregister"         {:get job-deregister/get}]
            ["/start"              {:get job-start/get}]

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -7,8 +7,6 @@
             [reitit.ring.malli]
             [malli.util :as mu]
             [source.middleware.interface :as mw]
-            [source.db.interface :as db]
-            [congest.jobs :as congest]
             [clojure.data.json :as json]
             [source.routes.user :as user]
             [source.routes.users :as users]
@@ -40,9 +38,7 @@
             [source.routes.job-deregister :as job-deregister]
             [source.routes.job-start :as job-start]
             [source.routes.job-stop :as job-stop]
-            [source.util :as util]
-            [source.datastore.interface :as store]
-            [source.jobs.core :as job-service]))
+            [source.util :as util]))
 
 (defn route [handlers]
   (reduce (fn [acc [k v]]
@@ -53,141 +49,144 @@
                              :handler v}})))
           {} handlers))
 
-(defn create-app []
-  (let [ds (db/ds :master)
-        store (store/ds :datahike)
-        js (congest/create-job-service [])]
-    (job-service/start-interrupted-jobs! js ds store)
-    (ring/ring-handler
-     (ring/router
-      [["/swagger.json"   {:get {:no-doc true
-                                 :swagger {:info {:title "source-api"
-                                                  :description "swagger docs for source api with malli and reitit-ring"
-                                                  :version "0.0.1"}
-                                           :securityDefinitions {"auth" {:type :apiKey
-                                                                         :in :header
-                                                                         :name "Authorization"}}}
-                                 :handler (swagger/create-swagger-handler)}}]
+(defn create-app [{:keys [ds store js]}]
+  (ring/ring-handler
+   (ring/router
+    [["/swagger.json"   {:get {:no-doc true
+                               :swagger {:info {:title "source-api"
+                                                :description "swagger docs for source api with malli and reitit-ring"
+                                                :version "0.0.1"}
+                                         :securityDefinitions {"auth" {:type :apiKey
+                                                                       :in :header
+                                                                       :name "Authorization"}}}
+                               :handler (swagger/create-swagger-handler)}}]
 
-       ["/openapi.json"   {:get {:no-doc true
-                                 :openapi {:info {:title "source-api"
-                                                  :description "openapi3 docs for source api with malli and reitit-ring"
-                                                  :version "0.0.1"}
-                                           :components {:securitySchemes {"bearerAuth" {:type :http
-                                                                                        :scheme :bearer
-                                                                                        :bearerFormat "JWT"
-                                                                                        :description "JWT Authorization using the Bearer scheme"}}}}
-                                 :handler (openapi/create-openapi-handler)}}]
+     ["/openapi.json"   {:get {:no-doc true
+                               :openapi {:info {:title "source-api"
+                                                :description "openapi3 docs for source api with malli and reitit-ring"
+                                                :version "0.0.1"}
+                                         :components {:securitySchemes {"bearerAuth" {:type :http
+                                                                                      :scheme :bearer
+                                                                                      :bearerFormat "JWT"
+                                                                                      :description "JWT Authorization using the Bearer scheme"}}}}
+                               :handler (openapi/create-openapi-handler)}}]
 
-       ["/users"          {:middleware [[mw/apply-auth {:required-type :admin}]]
-                           :tags #{"users"}
-                           :swagger {:security [{"auth" []}]}
-                           :openapi {:security [{:bearerAuth []}]}}
-        [""               (route {:get users/get})]
-        ["/:id"           (route {:get user/get
-                                  :patch user/patch})]]
+     ["/users"          {:middleware [[mw/apply-auth {:required-type :admin}]]
+                         :tags #{"users"}
+                         :swagger {:security [{"auth" []}]}
+                         :openapi {:security [{:bearerAuth []}]}}
+      [""               (route {:get users/get})]
+      ["/:id"           (route {:get user/get
+                                :patch user/patch})]]
 
-       ["/me"             {:middleware [[mw/apply-auth]]
-                           :tags #{"me"}
-                           :swagger {:security [{"auth" []}]}
-                           :openapi {:security [{:bearerAuth []}]}}
-        [""               (route {:get me/get})]]
+     ["/me"             {:middleware [[mw/apply-auth]]
+                         :tags #{"me"}
+                         :swagger {:security [{"auth" []}]}
+                         :openapi {:security [{:bearerAuth []}]}}
+      [""               (route {:get me/get})]]
 
-       ["/businesses"     {:middleware [[mw/apply-auth {:required-type :admin}]]
-                           :tags #{"businesses"}
-                           :swagger {:security [{"auth" []}]}
-                           :openapi {:security [{:bearerAuth []}]}}
-        [""               (route {:get businesses/get
-                                  :post business/post})]
-        ["/:id"           (route {:patch business/patch})]]
+     ["/businesses"     {:middleware [[mw/apply-auth {:required-type :admin}]]
+                         :tags #{"businesses"}
+                         :swagger {:security [{"auth" []}]}
+                         :openapi {:security [{:bearerAuth []}]}}
+      [""               (route {:get businesses/get
+                                :post business/post})]
+      ["/:id"           (route {:patch business/patch})]]
 
-       ["/sectors"        {:tags #{"sectors"}}
-        [""               (route {:get sectors/get})]]
+     ["/sectors"        {:tags #{"sectors"}}
+      [""               (route {:get sectors/get})]]
 
-       ["/login"          {:tags #{"auth"}}
-        [""               (route {:post login/post})]]
+     ["/login"          {:tags #{"auth"}}
+      [""               (route {:post login/post})]]
 
-       ["/register"       {:tags #{"auth"}}
-        [""               (route {:post register/post})]]
+     ["/register"       {:tags #{"auth"}}
+      [""               (route {:post register/post})]]
 
-       ["/oauth2"
-        ["/google"        {:tags #{"google"}}
-         [""              (route {:get google-launch/get})]
-         ["/callback"     {:no-doc true
-                           :get google-redirect/get}]
-         ["/user"         (route {:get google-user/get})]]]
+     ["/oauth2"
+      ["/google"        {:tags #{"google"}}
+       [""              (route {:get google-launch/get})]
+       ["/callback"     {:no-doc true
+                         :get google-redirect/get}]
+       ["/user"         (route {:get google-user/get})]]]
 
-       ["/protected"      {:middleware [[mw/apply-auth]]
-                           :tags #{"protected"}
-                           :swagger {:security [{"auth" []}]}
-                           :openapi {:security [{:bearerAuth []}]}}
-        ["/authorized"    (route {:get authorized/get})]]
+     ["/protected"      {:middleware [[mw/apply-auth]]
+                         :tags #{"protected"}
+                         :swagger {:security [{"auth" []}]}
+                         :openapi {:security [{:bearerAuth []}]}}
+      ["/authorized"    (route {:get authorized/get})]]
 
-       ["/providers"      {:tags #{"providers"}}
-        [""               (route {:get providers/get})]
-        ["/:id"           (route {:get provider/get})]]
+     ["/providers"      {:tags #{"providers"}}
+      [""               (route {:get providers/get})]
+      ["/:id"           (route {:get provider/get})]]
 
-       ["/content-types"  {:tags #{"content types"}}
-        [""               {:get content-types/get}]
-        ["/:id"           {:get content-type/get}]]
+     ["/content-types"  {:tags #{"content types"}}
+      [""               {:get content-types/get}]
+      ["/:id"           {:get content-type/get}]]
 
-       ["/feeds"          {:middleware [[mw/apply-auth]]
-                           :tags #{"feeds"}}
-        [""               (route {:get feeds/get
-                                  :post feeds/post})]]
+     ["/feeds"          {:middleware [[mw/apply-auth]]
+                         :tags #{"feeds"}}
+      [""               (route {:get feeds/get
+                                :post feeds/post})]]
 
-       ["/admin"                  {:middleware [[mw/apply-auth {:required-type :admin}]]
-                                   :no-doc true
-                                   :tags #{"admin"}
-                                   :swagger {:security [{"auth" []}]}
-                                   :openapi {:security [{:bearerAuth []}]}}
-        ["/jobs"
-         [""                      {:get jobs/get}]
-         ["/manage"
-          ["/register"            {:post jobs/post}]]
-         ["/:id"
-          [""                     {:get job/get}]
-          ["/manage"
-           ["/deregister"         {:get job-deregister/get}]
-           ["/start"              {:get job-start/get}]
-           ["/stop"               {:get job-stop/get}]]]]
-        ["/add-admin"             (route {:post admin/post})]
-        ["/selection-schemas"
-         [""                      {:get selection-schemas/get
-                                   :post selection-schemas/post}]
-         ["/:id"                  {:get selection-schema/get}]
-         ["/providers/:id"        {:get provider-selection-schemas/get}]]
-        ["/output-schemas"
-         [""                      {:get output-schemas/get
-                                   :post output-schemas/post}]
-         ["/:id"                  {:get output-schema/get}]]
-        ["/providers"
-         [""                      (route {:post providers/post})]
-         ["/:id"                  (route {:delete provider/delete})]]
-        ["/ast"                   {:post xml/post}]
-        ["/extract-data"          {:post data/post}]]]
+     ["/admin"                  {:middleware [[mw/apply-auth {:required-type :admin}]]
+                                 :no-doc true
+                                 :tags #{"admin"}
+                                 :swagger {:security [{"auth" []}]}
+                                 :openapi {:security [{:bearerAuth []}]}}
+      ["/jobs"
+       [""                      {:get jobs/get}]
+       ["/manage"
+        ["/register"            {:post jobs/post}]]
+       ["/:id"
+        [""                     {:get job/get}]
+        ["/manage"
+         ["/deregister"         {:get job-deregister/get}]
+         ["/start"              {:get job-start/get}]
+         ["/stop"               {:get job-stop/get}]]]]
+      ["/add-admin"             (route {:post admin/post})]
+      ["/selection-schemas"
+       [""                      {:get selection-schemas/get
+                                 :post selection-schemas/post}]
+       ["/:id"                  {:get selection-schema/get}]
+       ["/providers/:id"        {:get provider-selection-schemas/get}]]
+      ["/output-schemas"
+       [""                      {:get output-schemas/get
+                                 :post output-schemas/post}]
+       ["/:id"                  {:get output-schema/get}]]
+      ["/providers"
+       [""                      (route {:post providers/post})]
+       ["/:id"                  (route {:delete provider/delete})]]
+      ["/ast"                   {:post xml/post}]
+      ["/extract-data"          {:post data/post}]]]
 
-      {:data {:coercion (reitit.coercion.malli/create
-                         {:error-keys #{#_:type :coercion :in :schema :value :errors :humanized #_:transformed}
-                          :compile mu/closed-schema
-                          :strip-extra-keys true
-                          :default-values true
-                          :options nil})
-              :middleware [[mw/apply-generic :ds ds :store store :js js]]}})
-     (ring/routes
-      (swagger-ui/create-swagger-ui-handler {:path "/"
-                                             :config {:validatorUrl nil
-                                                      :urls [{:name "swagger", :url "swagger.json"}
-                                                             {:name "openapi", :url "openapi.json"}]
-                                                      :urls.primaryName "swagger"
-                                                      :operationsSorter "alpha"}})
-      (ring/create-default-handler)))))
+    {:data {:coercion (reitit.coercion.malli/create
+                       {:error-keys #{#_:type :coercion :in :schema :value :errors :humanized #_:transformed}
+                        :compile mu/closed-schema
+                        :strip-extra-keys true
+                        :default-values true
+                        :options nil})
+            :middleware [[mw/apply-generic :ds ds :store store :js js]]}})
+   (ring/routes
+    (swagger-ui/create-swagger-ui-handler {:path "/"
+                                           :config {:validatorUrl nil
+                                                    :urls [{:name "swagger", :url "swagger.json"}
+                                                           {:name "openapi", :url "openapi.json"}]
+                                                    :urls.primaryName "swagger"
+                                                    :operationsSorter "alpha"}})
+    (ring/create-default-handler))))
 
 (comment
   (require '[source.middleware.auth.util :as auth.util]
+           '[source.db.util :as db.util]
+           '[congest.jobs :as js]
+           '[source.datastore.interface :as store]
            '[source.rss.youtube :as yt])
 
-  (let [app (create-app)
+  (def components {:ds (db.util/conn)
+                   :store (store/ds :datahike)
+                   :js (js/create-job-service [])})
+
+  (let [app (create-app components)
         request {:uri "/users"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
@@ -196,7 +195,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/users/3"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
@@ -205,7 +204,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/users/3"
                  :request-method :patch
                  :body {:firstname "Keagan"
@@ -215,7 +214,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/protected/authorized"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 5 :type "distributor"}))}}]
@@ -224,7 +223,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/add-admin"
                  :request-method :post
                  :body {:email "test@test.com"
@@ -236,7 +235,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/oauth2/google"
                  :request-method :get}]
     (-> request
@@ -244,7 +243,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/businesses"
                  :request-method :get}]
     (-> request
@@ -252,7 +251,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/businesses"
                  :request-method :post
                  :body {:name "beep"
@@ -262,7 +261,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/businesses/1"
                  :request-method :patch
                  :body {:name "thebest"
@@ -272,7 +271,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/sectors"
                  :request-method :get}]
     (-> request
@@ -280,7 +279,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/providers"
                  :request-method :get}]
     (-> request
@@ -288,7 +287,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/providers/1"
                  :request-method :get}]
     (-> request
@@ -296,7 +295,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/content-types"
                  :request-method :get}]
     (-> request
@@ -304,7 +303,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/content-types/1"
                  :request-method :get}]
     (-> request
@@ -317,7 +316,7 @@
          (yt/find-channel-id)
          (str "https://www.youtube.com/feeds/videos.xml?channel_id=")))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/feeds"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 5 :type "creator"}))}}]
@@ -326,7 +325,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/feeds"
                  :request-method :post
                  :body {:title "primeagen test"
@@ -341,7 +340,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         store (store/ds :datahike)
         request {:uri "/admin/selection-schemas"
                  :request-method :post
@@ -355,7 +354,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/selection-schemas/1"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
@@ -364,7 +363,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         store (store/ds :datahike)
         request {:uri "/admin/selection-schemas"
                  :store store
@@ -380,7 +379,7 @@
          (yt/find-channel-id)
          (str "https://www.youtube.com/feeds/videos.xml?channel_id=")))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/ast"
                  :request-method :post
                  :body {:url (get-url)}
@@ -390,7 +389,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         store (store/ds :datahike)
         request {:uri "/admin/extract-data"
                  :store store
@@ -406,7 +405,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/jobs"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
@@ -415,7 +414,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/jobs/1"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
@@ -424,7 +423,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/jobs/manage/register"
                  :request-method :post
                  :body {:metadata {:initial-delay 10
@@ -442,7 +441,7 @@
         :body
         (json/read-json {:key-fn keyword})))
 
-  (let [app (create-app)
+  (let [app (create-app components)
         request {:uri "/admin/jobs/1/manage/deregister"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -5,10 +5,10 @@
             [reitit.openapi :as openapi]
             [reitit.coercion.malli]
             [reitit.ring.malli]
-            [reitit.ring.middleware.exception :as exception]
             [malli.util :as mu]
             [source.middleware.interface :as mw]
             [source.db.interface :as db]
+            [congest.jobs :as congest]
             [clojure.data.json :as json]
             [source.routes.user :as user]
             [source.routes.users :as users]
@@ -32,10 +32,17 @@
             [source.routes.provider :as provider]
             [source.routes.content-types :as content-types]
             [source.routes.content-type :as content-type]
+            [source.routes.feeds :as feeds]
             [source.routes.xml :as xml]
             [source.routes.data :as data]
+            [source.routes.jobs :as jobs]
+            [source.routes.job :as job]
+            [source.routes.job-deregister :as job-deregister]
+            [source.routes.job-start :as job-start]
+            [source.routes.job-stop :as job-stop]
             [source.util :as util]
-            [source.datastore.interface :as store]))
+            [source.datastore.interface :as store]
+            [source.jobs.core :as job-service]))
 
 (defn route [handlers]
   (reduce (fn [acc [k v]]
@@ -48,85 +55,102 @@
 
 (defn create-app []
   (let [ds (db/ds :master)
-        store (store/ds :datahike)]
+        store (store/ds :datahike)
+        js (congest/create-job-service [])]
+    (job-service/kill-all! js)
+    (job-service/start-interrupted-jobs! js ds)
     (ring/ring-handler
      (ring/router
-      [["/swagger.json" {:get {:no-doc true
-                               :swagger {:info {:title "source-api"
-                                                :description "swagger docs for source api with malli and reitit-ring"
-                                                :version "0.0.1"}
-                                         :securityDefinitions {"auth" {:type :apiKey
-                                                                       :in :header
-                                                                       :name "Authorization"}}}
-                               :handler (swagger/create-swagger-handler)}}]
+      [["/swagger.json"   {:get {:no-doc true
+                                 :swagger {:info {:title "source-api"
+                                                  :description "swagger docs for source api with malli and reitit-ring"
+                                                  :version "0.0.1"}
+                                           :securityDefinitions {"auth" {:type :apiKey
+                                                                         :in :header
+                                                                         :name "Authorization"}}}
+                                 :handler (swagger/create-swagger-handler)}}]
 
-       ["/openapi.json" {:get {:no-doc true
-                               :openapi {:info {:title "source-api"
-                                                :description "openapi3 docs for source api with malli and reitit-ring"
-                                                :version "0.0.1"}
-                                         :components {:securitySchemes {"bearerAuth" {:type :http
-                                                                                      :scheme :bearer
-                                                                                      :bearerFormat "JWT"
-                                                                                      :description "JWT Authorization using the Bearer scheme"}}}}
-                               :handler (openapi/create-openapi-handler)}}]
+       ["/openapi.json"   {:get {:no-doc true
+                                 :openapi {:info {:title "source-api"
+                                                  :description "openapi3 docs for source api with malli and reitit-ring"
+                                                  :version "0.0.1"}
+                                           :components {:securitySchemes {"bearerAuth" {:type :http
+                                                                                        :scheme :bearer
+                                                                                        :bearerFormat "JWT"
+                                                                                        :description "JWT Authorization using the Bearer scheme"}}}}
+                                 :handler (openapi/create-openapi-handler)}}]
 
-       ["/users"        {:middleware [[mw/apply-auth {:required-type :admin}]]
-                         :tags #{"users"}
-                         :swagger {:security [{"auth" []}]}
-                         :openapi {:security [{:bearerAuth []}]}}
-        [""             (route {:get users/get})]
-        ["/:id"         (route {:get user/get
-                                :patch user/patch})]]
+       ["/users"          {:middleware [[mw/apply-auth {:required-type :admin}]]
+                           :tags #{"users"}
+                           :swagger {:security [{"auth" []}]}
+                           :openapi {:security [{:bearerAuth []}]}}
+        [""               (route {:get users/get})]
+        ["/:id"           (route {:get user/get
+                                  :patch user/patch})]]
 
-       ["/me"           {:middleware [[mw/apply-auth]]
-                         :tags #{"me"}
-                         :swagger {:security [{"auth" []}]}
-                         :openapi {:security [{:bearerAuth []}]}}
-        [""             (route {:get me/get})]]
+       ["/me"             {:middleware [[mw/apply-auth]]
+                           :tags #{"me"}
+                           :swagger {:security [{"auth" []}]}
+                           :openapi {:security [{:bearerAuth []}]}}
+        [""               (route {:get me/get})]]
 
-       ["/businesses"   {:middleware [[mw/apply-auth {:required-type :admin}]]
-                         :tags #{"businesses"}
-                         :swagger {:security [{"auth" []}]}
-                         :openapi {:security [{:bearerAuth []}]}}
-        [""             (route {:get businesses/get
-                                :post business/post})]
-        ["/:id"         (route {:patch business/patch})]]
+       ["/businesses"     {:middleware [[mw/apply-auth {:required-type :admin}]]
+                           :tags #{"businesses"}
+                           :swagger {:security [{"auth" []}]}
+                           :openapi {:security [{:bearerAuth []}]}}
+        [""               (route {:get businesses/get
+                                  :post business/post})]
+        ["/:id"           (route {:patch business/patch})]]
 
-       ["/sectors"      {:tags #{"sectors"}}
-        [""             (route {:get sectors/get})]]
+       ["/sectors"        {:tags #{"sectors"}}
+        [""               (route {:get sectors/get})]]
 
-       ["/login"        {:tags #{"auth"}}
-        [""             (route {:post login/post})]]
+       ["/login"          {:tags #{"auth"}}
+        [""               (route {:post login/post})]]
 
-       ["/register"     {:tags #{"auth"}}
-        [""             (route {:post register/post})]]
+       ["/register"       {:tags #{"auth"}}
+        [""               (route {:post register/post})]]
 
        ["/oauth2"
-        ["/google"      {:tags #{"google"}}
-         [""            (route {:get google-launch/get})]
-         ["/callback"   {:no-doc true
-                         :get google-redirect/get}]
-         ["/user"       (route {:get google-user/get})]]]
+        ["/google"        {:tags #{"google"}}
+         [""              (route {:get google-launch/get})]
+         ["/callback"     {:no-doc true
+                           :get google-redirect/get}]
+         ["/user"         (route {:get google-user/get})]]]
 
-       ["/protected"    {:middleware [[mw/apply-auth]]
-                         :tags #{"protected"}
-                         :swagger {:security [{"auth" []}]}
-                         :openapi {:security [{:bearerAuth []}]}}
-        ["/authorized"  (route {:get authorized/get})]]
+       ["/protected"      {:middleware [[mw/apply-auth]]
+                           :tags #{"protected"}
+                           :swagger {:security [{"auth" []}]}
+                           :openapi {:security [{:bearerAuth []}]}}
+        ["/authorized"    (route {:get authorized/get})]]
 
-       ["/providers"
-        [""             {:get providers/get}]
-        ["/:id"         {:get provider/get}]]
+       ["/providers"      {:tags #{"providers"}}
+        [""               (route {:get providers/get})]
+        ["/:id"           (route {:get provider/get})]]
 
-       ["/content-types"
-        [""             {:get content-types/get}]
-        ["/:id"         {:get content-type/get}]]
+       ["/content-types"  {:tags #{"content types"}}
+        [""               {:get content-types/get}]
+        ["/:id"           {:get content-type/get}]]
+
+       ["/feeds"          {:middleware [[mw/apply-auth]]
+                           :tags #{"feeds"}}
+        [""               (route {:get feeds/get
+                                  :post feeds/post})]]
 
        ["/admin"                  {:middleware [[mw/apply-auth {:required-type :admin}]]
                                    :no-doc true
                                    :tags #{"admin"}
                                    :swagger {:security [{"auth" []}]}
                                    :openapi {:security [{:bearerAuth []}]}}
+        ["/jobs"
+         [""                      {:get jobs/get}]
+         ["/manage"
+          ["/register"            {:post jobs/post}]]
+         ["/:id"                  {:get job/get}
+          ["/manage"
+           ["/deregister"         {:get job-deregister/get}]
+           ["/start"              {:get job-start/get}]
+           ["/stop"               {:get job-stop/get}]]]]
         ["/add-admin"             (route {:post admin/post})]
         ["/selection-schemas"
          [""                      {:get selection-schemas/get
@@ -138,8 +162,8 @@
                                    :post output-schemas/post}]
          ["/:id"                  {:get output-schema/get}]]
         ["/providers"
-         [""                      {:post providers/post}]
-         ["/:id"                  {:delete provider/delete}]]
+         [""                      (route {:post providers/post})]
+         ["/:id"                  (route {:delete provider/delete})]]
         ["/ast"                   {:post xml/post}]
         ["/extract-data"          {:post data/post}]]]
 
@@ -149,9 +173,7 @@
                           :strip-extra-keys true
                           :default-values true
                           :options nil})
-              :middleware [[mw/apply-generic :ds ds :store store]
-                           ;;[exception/exception-middleware]
-                           ]}})
+              :middleware [[mw/apply-generic :ds ds :store store :js js]]}})
      (ring/routes
       (swagger-ui/create-swagger-ui-handler {:path "/"
                                              :config {:validatorUrl nil
@@ -166,14 +188,18 @@
            '[source.rss.youtube :as yt])
 
   (let [app (create-app)
-        request {:uri "/users" :request-method :get}]
+        request {:uri "/users"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
     (-> request
         app
         :body
         (json/read-json {:key-fn keyword})))
 
   (let [app (create-app)
-        request {:uri "/users/3" :request-method :get}]
+        request {:uri "/users/3"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
     (-> request
         app
         :body
@@ -286,6 +312,35 @@
         :body
         (json/read-json {:key-fn keyword})))
 
+  (defn get-url []
+    (->> "https://www.youtube.com/@ThePrimeTimeagen"
+         (yt/find-channel-id)
+         (str "https://www.youtube.com/feeds/videos.xml?channel_id=")))
+
+  (let [app (create-app)
+        request {:uri "/admin/feeds"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 5 :type "creator"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/admin/feeds"
+                 :request-method :post
+                 :body {:title "primeagen test"
+                        :rss-url (get-url)
+                        :provider-id 1
+                        :content-type-id 1
+                        :cadence-id 1
+                        :baseline-id 1}
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 5 :type "creator"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
   (let [app (create-app)
         store (store/ds :datahike)
         request {:uri "/admin/selection-schemas"
@@ -346,6 +401,51 @@
     (println (store/entities-with store :selection-schemas/id))
     (println (store/find-entities store {:key :selection-schemas/id
                                          :value 1}))
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/admin/jobs"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/admin/jobs/1"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/admin/jobs/manage/register"
+                 :request-method :post
+                 :body {:metadata {:initial-delay 10
+                                   :auto-start true
+                                   :stop-after-fail false,
+                                   :interval 1000
+                                   :recurring? true
+                                   :handler "test"
+                                   :created-at nil
+                                   :sleep false}
+                        :args {:name "congest"}}
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
+    (-> request
+        app
+        :body
+        (json/read-json {:key-fn keyword})))
+
+  (let [app (create-app)
+        request {:uri "/admin/jobs/1/manage/deregister"
+                 :request-method :get
+                 :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
     (-> request
         app
         :body

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -57,7 +57,6 @@
   (let [ds (db/ds :master)
         store (store/ds :datahike)
         js (congest/create-job-service [])]
-    (job-service/kill-all! js)
     (job-service/start-interrupted-jobs! js ds store)
     (ring/ring-handler
      (ring/router
@@ -432,10 +431,10 @@
                                    :stop-after-fail false,
                                    :interval 1000
                                    :recurring? true
+                                   :args {:name "congest"}
                                    :handler "test"
                                    :created-at nil
-                                   :sleep false}
-                        :args {:name "congest"}}
+                                   :sleep false}}
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
     (-> request
         app

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -58,7 +58,7 @@
         store (store/ds :datahike)
         js (congest/create-job-service [])]
     (job-service/kill-all! js)
-    (job-service/start-interrupted-jobs! js ds)
+    (job-service/start-interrupted-jobs! js ds store)
     (ring/ring-handler
      (ring/router
       [["/swagger.json"   {:get {:no-doc true

--- a/src/source/routes/selection_schema.clj
+++ b/src/source/routes/selection_schema.clj
@@ -4,13 +4,15 @@
 
 (defn get [{:keys [ds path-params store] :as _request}]
   (let [{:keys [output-schema-id] :as selection-schema}
-        (services/selection-schema ds (:id path-params))
+        (services/selection-schema ds path-params)
         output-schema (services/output-schema store output-schema-id)]
     (res/response (merge {:output-schema output-schema}
                          selection-schema))))
 
 (comment
-  (require '[source.db.util :as db.util])
+  (require '[source.db.util :as db.util]
+           '[source.datastore.util :as store.util])
   (get {:ds (db.util/conn)
+        :store (store.util/conn :datahike)
         :path-params {:id 1}})
   ())

--- a/src/source/routes/selection_schemas.clj
+++ b/src/source/routes/selection_schemas.clj
@@ -7,7 +7,7 @@
       (res/response)))
 
 (defn post [{:keys [store ds body] :as _request}]
-  (-> (services/add-selection-schema! store ds body)
+  (-> (services/insert-selection-schema! store ds body)
       (first)
       (res/response)))
 

--- a/src/source/server.clj
+++ b/src/source/server.clj
@@ -7,57 +7,97 @@
             [source.routes.interface :as routes]
             [source.util :as util]))
 
-(defonce ^:private *server (atom nil))
-
 (defonce ^:private *components (atom nil))
 
-(defn initialise-components! []
-  (if (some? @*components)
-    (do
-      (println "Components already initialised.")
-      (let [{:keys [ds store]} @*components]
-        (->> (jobs/interrupted-jobs ds store)
-             (congest/create-job-service)
-             (swap! *components assoc :js))))
+(defn initialise-server! [{:keys [ds store js]}]
+  (http/run-server
+   (routes/create-app {:ds ds
+                       :store store
+                       :js js})
+   {:port 3000}))
 
-    (try
-      (println "Initialising components...")
-      (let [{:keys [ds store]} (reset! *components {:ds (db/ds :master)
-                                                    :store (store/ds :datahike)})]
-        (->> (jobs/interrupted-jobs ds store)
-             (congest/create-job-service)
-             (swap! *components assoc :js)))
-      (catch Exception e (println "Failed to initialise components: " (.getMessage e))))))
+(defn initialise-job-service! [{:keys [ds store] :as _deps}]
+  (->> (jobs/interrupted-jobs ds store)
+       (congest/create-job-service)))
+
+(defn component-on? [component]
+  (if (some? (get @*components component))
+    true
+    false))
+
+(defn deps-on? [deps]
+  (every? component-on? deps))
+
+(defn initialise!
+  "executes the init-fn on the provided component and, if successful, updates the components atom with the new component"
+  [{:keys [name init-fn deps] :as _component}]
+  (try
+    (when (deps-on? deps)
+      (swap! *components assoc name (init-fn @*components)))
+    (catch Exception e (println (str "Failed to initialise " name ":") e))))
+
+(defn initialise-components! [components]
+  (run! initialise! components))
 
 (defn running? []
-  (some? @*server))
+  (some? (:server @*components)))
 
 (defn start-server []
-  (cond (not (some? @*server))
+  (cond (not (some? (:server @*components)))
         (do
           (println "Starting server on port 3000...")
-          (initialise-components!)
-          (reset! *server (http/run-server
-                           (routes/create-app @*components)
-                           {:port 3000})))
+          (initialise-components! [{:name :ds
+                                    :init-fn (fn [_deps] (db/ds :master))
+                                    :deps []}
+                                   {:name :store
+                                    :init-fn (fn [_deps] (store/ds :datahike))
+                                    :deps []}
+                                   {:name :js
+                                    :deps [:ds :store]
+                                    :init-fn initialise-job-service!}
+                                   {:name :server
+                                    :deps [:ds :store :js]
+                                    :init-fn initialise-server!}]))
         :else
         (println "Server already running!")))
 
 (defn stop-server []
   (println "Stopping server...")
-  (when (some? @*components)
+  (when (some? (:js @*components))
     (congest/kill! (:js @*components)))
-  (when (some? @*server)
-    (@*server))
-  (reset! *server nil))
+  (when (some? (:server @*components))
+    (let [server (:server @*components)]
+      (server)))
+  (reset! *components nil))
 
-(defn restart-server []
-  (stop-server)
-  (start-server))
+(defn restart-server [& {:keys [keep-js]}]
+  (if keep-js
+    (do
+      (when (some? (:server @*components))
+        (let [server (:server @*components)]
+          (server)))
+      (swap! *components select-keys [:js])
+      (initialise-components! [{:name :ds
+                                :init-fn (fn [_deps] (db/ds :master))
+                                :deps []}
+                               {:name :store
+                                :init-fn (fn [_deps] (store/ds :datahike))
+                                :deps []}
+                               {:name :server
+                                :deps [:ds :store :js]
+                                :init-fn initialise-server!}]))
+    (do
+      (stop-server)
+      (start-server))))
 
 (comment
+  (start-server)
+  (stop-server)
+  (restart-server)
+  (restart-server :keep-js true)
   (def test-wrapper
     (util/wrap-json (fn [request] request)))
   (test-wrapper {:status 200
                  :body "{\"value\":\"Hello, Source!\"}"
-                 :headers {"Content-Type" "application/json"}}))
+                 :headers {"Content-Type" "application/json"}})
+  ())

--- a/src/source/server.clj
+++ b/src/source/server.clj
@@ -66,16 +66,16 @@
   (when (some? (:js @*components))
     (congest/kill! (:js @*components)))
   (when (some? (:server @*components))
-    (let [server (:server @*components)]
-      (server)))
+    (let [server-stop (:server @*components)]
+      (server-stop)))
   (reset! *components nil))
 
 (defn restart-server [& {:keys [keep-js]}]
   (if keep-js
     (do
       (when (some? (:server @*components))
-        (let [server (:server @*components)]
-          (server)))
+        (let [server-stop (:server @*components)]
+          (server-stop)))
       (swap! *components select-keys [:js])
       (initialise-components! [{:name :ds
                                 :init-fn (fn [_deps] (db/ds :master))

--- a/src/source/server.clj
+++ b/src/source/server.clj
@@ -1,10 +1,33 @@
 (ns source.server
-  (:require
-   [org.httpkit.server :as http]
-   [source.routes.interface :as routes]
-   [source.util :as util]))
+  (:require [org.httpkit.server :as http]
+            [source.db.interface :as db]
+            [source.datastore.interface :as store]
+            [congest.jobs :as congest]
+            [source.jobs.core :as jobs]
+            [source.routes.interface :as routes]
+            [source.util :as util]))
 
 (defonce ^:private *server (atom nil))
+
+(defonce ^:private *components (atom nil))
+
+(defn initialise-components! []
+  (if (some? @*components)
+    (do
+      (println "Components already initialised.")
+      (let [{:keys [ds store]} @*components]
+        (->> (jobs/interrupted-jobs ds store)
+             (congest/create-job-service)
+             (swap! *components assoc :js))))
+
+    (try
+      (println "Initialising components...")
+      (let [{:keys [ds store]} (reset! *components {:ds (db/ds :master)
+                                                    :store (store/ds :datahike)})]
+        (->> (jobs/interrupted-jobs ds store)
+             (congest/create-job-service)
+             (swap! *components assoc :js)))
+      (catch Exception e (println "Failed to initialise components: " (.getMessage e))))))
 
 (defn running? []
   (some? @*server))
@@ -13,14 +36,17 @@
   (cond (not (some? @*server))
         (do
           (println "Starting server on port 3000...")
+          (initialise-components!)
           (reset! *server (http/run-server
-                           (routes/create-app)
+                           (routes/create-app @*components)
                            {:port 3000})))
         :else
         (println "Server already running!")))
 
 (defn stop-server []
   (println "Stopping server...")
+  (when (some? @*components)
+    (congest/kill! (:js @*components)))
   (when (some? @*server)
     (@*server))
   (reset! *server nil))
@@ -35,4 +61,3 @@
   (test-wrapper {:status 200
                  :body "{\"value\":\"Hello, Source!\"}"
                  :headers {"Content-Type" "application/json"}}))
-

--- a/src/source/services/baselines.clj
+++ b/src/source/services/baselines.clj
@@ -1,23 +1,23 @@
-(ns source.services.content-types
+(ns source.services.baselines
   (:require [source.db.interface :as db]))
 
-(defn insert-content-type! [ds {:keys [data ret] :as opts}]
-  (->> {:tname :content-types
+(defn insert-baseline! [ds {:keys [data ret] :as opts}]
+  (->> {:tname :baselines
         :data data
         :ret ret}
        (merge opts)
        (db/insert! ds)))
 
-(defn content-types
-  ([ds] (content-types ds {}))
+(defn baselines
+  ([ds] (baselines ds {}))
   ([ds opts]
-   (->> {:tname :content-types
+   (->> {:tname :baselines
          :ret :*}
         (merge opts)
         (db/find ds))))
 
-(defn content-type [ds {:keys [id where] :as opts}]
-  (->> {:tname :content-types
+(defn baseline [ds {:keys [id where] :as opts}]
+  (->> {:tname :baselines
         :where (if (some? id)
                  [:= :id id]
                  where)

--- a/src/source/services/cadences.clj
+++ b/src/source/services/cadences.clj
@@ -1,23 +1,23 @@
-(ns source.services.content-types
+(ns source.services.cadences
   (:require [source.db.interface :as db]))
 
-(defn insert-content-type! [ds {:keys [data ret] :as opts}]
-  (->> {:tname :content-types
+(defn insert-cadence! [ds {:keys [data ret] :as opts}]
+  (->> {:tname :cadences
         :data data
         :ret ret}
        (merge opts)
        (db/insert! ds)))
 
-(defn content-types
-  ([ds] (content-types ds {}))
+(defn cadences
+  ([ds] (cadences ds {}))
   ([ds opts]
-   (->> {:tname :content-types
+   (->> {:tname :cadences
          :ret :*}
         (merge opts)
         (db/find ds))))
 
-(defn content-type [ds {:keys [id where] :as opts}]
-  (->> {:tname :content-types
+(defn cadence [ds {:keys [id where] :as opts}]
+  (->> {:tname :cadences
         :where (if (some? id)
                  [:= :id id]
                  where)

--- a/src/source/services/feeds.clj
+++ b/src/source/services/feeds.clj
@@ -1,0 +1,35 @@
+(ns source.services.feeds
+  (:require [source.db.interface :as db]))
+
+(defn insert-feed! [ds {:keys [data] :as opts}]
+  (->> {:tname :feeds
+        :data data
+        :ret :1}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-feed! [ds {:keys [id data where] :as opts}]
+  (->> {:tname :feeds
+        :values data
+        :where (if (some? id) [:= :id id] where)
+        :ret :1}
+       (merge opts)
+       (db/update! ds)))
+
+(defn feeds
+  ([ds] (feeds ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :feeds
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn feed [ds {:keys [id where] :as opts}]
+  (->> {:tname :feeds
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/find ds)))

--- a/src/source/services/incoming_posts.clj
+++ b/src/source/services/incoming_posts.clj
@@ -1,0 +1,35 @@
+(ns source.services.incoming-posts
+  (:require [source.db.interface :as db]))
+
+(defn insert-incoming-post! [ds {:keys [data] :as opts}]
+  (->> {:tname :incoming-posts
+        :data data
+        :ret :1}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-incoming-post! [ds {:keys [id data where] :as opts}]
+  (->> {:tname :incoming-posts
+        :data data
+        :where (if (some? id) [:= :id id] where)
+        :ret :1}
+       (merge opts)
+       (db/update! ds)))
+
+(defn incoming-posts
+  ([ds] (incoming-posts ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :incoming-posts
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn incoming-post [ds {:keys [id where] :as opts}]
+  (->> {:tname :incoming-posts
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/find ds)))

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -5,7 +5,12 @@
              [source.services.xml-schemas :as xml]
              [source.services.bundles :as bundles]
              [source.services.providers :as providers]
-             [source.services.content-types :as content-types]))
+             [source.services.feeds :as feeds]
+             [source.services.incoming-posts :as incoming-posts]
+             [source.services.cadences :as cadences]
+             [source.services.baselines :as baselines]
+             [source.services.content-types :as content-types]
+             [source.services.jobs :as jobs]))
 
 (defn users
   [& args]
@@ -26,8 +31,8 @@
 (defn register [ds user]
   (auth/register ds user))
 
-(defn add-selection-schema! [store db {:keys [_schema _record] :as opts}]
-  (xml/add-selection-schema! store db opts))
+(defn insert-selection-schema! [store db {:keys [_schema _record] :as opts}]
+  (xml/insert-selection-schema! store db opts))
 
 (defn selection-schema [ds {:keys [_id] :as opts}]
   (xml/selection-schema ds opts))
@@ -41,6 +46,9 @@
 (defn selection-schemas-by-provider [ds {:keys [_provider-id] :as opts}]
   (xml/selection-schemas-by-provider ds opts))
 
+(defn delete-selection-schemas-by-provider! [store db provider-id]
+  (xml/delete-selection-schemas-by-provider! store db provider-id))
+
 (defn ast [url]
   (xml/ast url))
 
@@ -53,8 +61,8 @@
 (defn output-schema [store output-schema-id]
   (xml/output-schema store output-schema-id))
 
-(defn add-output-schema! [store schema]
-  (xml/add-output-schema! store schema))
+(defn insert-output-schema! [store schema]
+  (xml/insert-output-schema! store schema))
 
 (defn providers [ds]
   (providers/providers ds))
@@ -74,8 +82,85 @@
 (defn content-type [ds id]
   (content-types/content-type ds id))
 
-(defn add-content-type! [ds {:keys [_values _ret] :as opts}]
-  (content-types/add-content-type! ds opts))
+(defn insert-content-type! [ds {:keys [_values _ret] :as opts}]
+  (content-types/insert-content-type! ds opts))
+
+(defn insert-feed! [ds {:keys [_data] :as opts}]
+  (feeds/insert-feed! ds opts))
+
+(defn update-feed! [ds {:keys [_id _data _where] :as opts}]
+  (feeds/update-feed! ds opts))
+
+(defn feeds
+  ([ds]
+   (feeds/feeds ds))
+  ([ds {:keys [_where] :as opts}]
+   (feeds/feeds ds opts)))
+
+(defn feed [ds id]
+  (feeds/feed ds id))
+
+(defn insert-incoming-post! [ds {:keys [_data] :as opts}]
+  (incoming-posts/insert-incoming-post! ds opts))
+
+(defn update-incoming-post! [ds {:keys [_id _data _where] :as opts}]
+  (incoming-posts/update-incoming-post! ds opts))
+
+(defn incoming-posts
+  ([ds]
+   (incoming-posts/incoming-posts ds))
+  ([ds {:keys [_where] :as opts}]
+   (incoming-posts/incoming-posts ds opts)))
+
+(defn incoming-post [ds id]
+  (incoming-posts/incoming-post ds id))
+
+(defn insert-cadence! [ds {:keys [_values _ret] :as opts}]
+  (cadences/insert-cadence! ds opts))
+
+(defn cadences [ds]
+  (cadences/cadences ds))
+
+(defn cadence [ds id]
+  (cadences/cadence ds id))
+
+(defn insert-baseline! [ds {:keys [_values _ret] :as opts}]
+  (baselines/insert-baseline! ds opts))
+
+(defn baselines [ds]
+  (baselines/baselines ds))
+
+(defn baseline [ds id]
+  (baselines/baseline ds id))
+
+(defn insert-job! [ds {:keys [_data _ret] :as opts}]
+  (jobs/insert-job! ds opts))
+
+(defn update-job! [ds {:keys [_id _data _where] :as opts}]
+  (jobs/update-job! ds opts))
+
+(defn delete-job! [ds {:keys [_id _where] :as opts}]
+  (jobs/delete-job! ds opts))
+
+(defn jobs
+  ([ds] (jobs ds {}))
+  ([ds opts]
+   (jobs/jobs ds opts)))
+
+(defn job [ds {:keys [_id _where] :as opts}]
+  (jobs/job ds opts))
+
+(defn insert-job-metadata! [ds {:keys [_data _ret] :as opts}]
+  (jobs/insert-job-metadata! ds opts))
+
+(defn update-job-metadata! [ds {:keys [_id _data _where] :as opts}]
+  (jobs/update-job-metadata! ds opts))
+
+(defn delete-job-metadata! [ds {:keys [_id _where] :as opts}]
+  (jobs/delete-job-metadata! ds opts))
+
+(defn job-metadata [ds {:keys [_id _where] :as opts}]
+  (jobs/job-metadata ds opts))
 
 (comment
   (users (db/ds :master))

--- a/src/source/services/jobs.clj
+++ b/src/source/services/jobs.clj
@@ -1,0 +1,72 @@
+(ns source.services.jobs
+  (:require [source.db.interface :as db]))
+
+(defn insert-job! [ds {:keys [data ret] :as opts}]
+  (->> {:tname :jobs
+        :data data
+        :ret ret}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-job! [ds {:keys [id data where] :as opts}]
+  (->> {:tname :jobs
+        :values data
+        :where (if (some? id) [:= :id id] where)}
+       (merge opts)
+       (db/update! ds)))
+
+(defn delete-job! [ds {:keys [id where] :as opts}]
+  (->> {:tname :jobs
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))
+
+(defn jobs
+  ([ds] (jobs ds {}))
+  ([ds opts]
+   (->> {:tname :jobs
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn job [ds {:keys [id where] :as opts}]
+  (->> {:tname :jobs
+        :where (if (some? id) [:= :id id] where)
+        :ret :1}
+       (merge opts)
+       (db/find ds)))
+
+(defn insert-job-metadata! [ds {:keys [data ret] :as opts}]
+  (->> {:tname :job-metadata
+        :data data
+        :ret ret}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-job-metadata! [ds {:keys [id data where] :as opts}]
+  (->> {:tname :job-metadata
+        :values data
+        :where (if (some? id) [:= :id id] where)}
+       (merge opts)
+       (db/update! ds)))
+
+(defn delete-job-metadata! [ds {:keys [id where] :as opts}]
+  (->> {:tname :job-metadata
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))
+
+(defn job-metadata [ds {:keys [id where] :as opts}]
+  (->> {:tname :job-metadata
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/find ds)))

--- a/src/source/services/xml_schemas.clj
+++ b/src/source/services/xml_schemas.clj
@@ -3,7 +3,7 @@
             [source.db.interface :as db]
             [source.rss.core :as rss]))
 
-(defn add-output-schema!
+(defn insert-output-schema!
   [store schema]
   (let [id (-> (store/entries store :output-schemas/id)
                (count)
@@ -22,7 +22,7 @@
        (store/find-entities store)
        (first)))
 
-(defn add-selection-schema!
+(defn insert-selection-schema!
   [store db {:keys [schema record]}]
   (let [{:keys [output-schema-id provider-id]} record
         db-result (db/insert! db {:tname :selection-schemas
@@ -31,6 +31,18 @@
                                   :ret :1})]
     (store/insert! store {:selection-schemas/id (:id db-result)
                           :selection-schemas/schema schema})))
+
+(defn delete-selection-schemas-by-provider!
+  [store db provider-id]
+  (let [selection-schemas (db/find db {:tname :selection-schemas
+                                       :where [:= :provider-id provider-id]
+                                       :ret :*})]
+    (run! (fn [{:keys [id]}]
+            (->> (store/find store {:key :selection-schemas/id
+                                    :value id})
+                 (store/delete! store))) selection-schemas)
+    (db/delete! db {:tname :selection-schemas
+                    :where [:= :provider-id provider-id]})))
 
 (defn selection-schemas
   ([ds] (selection-schemas ds {}))
@@ -80,8 +92,8 @@
   (require '[source.db.util :as db.util])
   (ast "https://www.youtube.com/feeds/videos.xml?channel_id=UCUyeluBRhGPCW4rPe_UvBZQ")
 
-  (reduce (fn [acc {:keys [version]}]
-            (conj acc version)) [] [{:version 2} {:version 3}])
+  (reduce (fn [acc {:keys [id]}]
+            (conj acc id)) [] [{:id 2} {:id 3}])
 
   (db/find (db.util/conn) {:tname :selection-schemas
                            :where [:and
@@ -103,7 +115,7 @@
    1
    "https://www.youtube.com/feeds/videos.xml?channel_id=UCUyeluBRhGPCW4rPe_UvBZQ")
 
-  (add-selection-schema!
+  (insert-selection-schema!
    ds
    (db.util/conn)
    {:record {:provider-id 1


### PR DESCRIPTION
Integrated Congest into Source. There is now a Job Scheduler that can be used from within Source itself and by admins. Scheduled jobs are persisted in sqlite and are recoverable at server startup or by admins. The sqlite tables store the job's status, metadata, args and handler identifiers.

In addition, feeds routes have been added to view all feeds, and to allow a creator to add a new feed. Adding a new feed creates a feed record, extracts RSS feed data and creates an incoming post, then schedules a job to update both the feed and the post every 24 hours.
