### PR TITLE
feat/creator-feed-api

### DIFF
--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -141,6 +141,7 @@
   (tables/create-table-sql
    :incoming-posts
    (tables/table-id)
+   [:post-id :text :not nil]
    [:feed-id :integer :not nil]
    [:title :text :not nil]
    [:info :text]

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -14,15 +14,35 @@
   (fn [{:keys [args]}]
     (println "hello" (get args :name) args)))
 
-(defmethod handler :update-feed-post [_]
+(defmethod handler :update-feed-posts [_]
   (fn [{:keys [args ds store]}]
     (try
-      (let [{:keys [feed-id post-id schema-id url]} args
-            extracted (services/extract-data store {:schema-id schema-id
-                                                    :url url})]
+      (let [{:keys [feed-id creator-id content-type-id provider-id url]} args
+            selection-schemas (->> [:= :provider-id provider-id]
+                                   (assoc {} :where)
+                                   (services/selection-schemas ds))
+            latest-ss (->> selection-schemas
+                           (reduce (fn [acc {:keys [id]}]
+                                     (conj acc id)) [])
+                           (apply max -1))
+            extracted (services/extract-data store {:schema-id latest-ss
+                                                    :url url})
+            extracted-posts (get-in extracted [:feed :posts])
+            extended-posts (mapv (fn [post]
+                                   (merge post
+                                          {:feed-id feed-id
+                                           :creator-id creator-id
+                                           :content-type-id content-type-id})) extracted-posts)
+            existing-posts (services/incoming-posts ds {:where [:= :creator-id creator-id]})]
         (services/update-feed! ds {:id feed-id
-                                   :data {:updated-at (util/get-utc-timestamp-string)}})
-        (services/update-incoming-post! ds {:id post-id
-                                            :data extracted}))
+                                   :data {:title (get-in extracted [:feed :title])
+                                          :updated-at (util/get-utc-timestamp-string)}})
+        (run!
+         (fn [post]
+           (if (some #(= (:post-id post) (:post-id %)) existing-posts)
+             (services/update-incoming-post! ds {:where [:= :post-id (:post-id post)]
+                                                 :data post})
+             (services/insert-incoming-post! ds {:data post})))
+         extended-posts))
       (catch Exception _ :fail))))
 

--- a/src/source/routes/feed.clj
+++ b/src/source/routes/feed.clj
@@ -1,0 +1,29 @@
+(ns source.routes.feed
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get feed by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "feed id"} :int]]}
+   :responses  {200 {:body [:map
+                            [:id :int]
+                            [:title :string]
+                            [:display-picture [:maybe :string]]
+                            [:url [:maybe :string]]
+                            [:rss-url :string]
+                            [:user-id [:maybe :int]]
+                            [:provider-id [:maybe :int]]
+                            [:created-at :string]
+                            [:updated-at [:maybe :string]]
+                            [:content-type-id :int]
+                            [:cadence-id :int]
+                            [:baseline-id :int]
+                            [:ts-and-cs [:maybe :string]]
+                            [:state [:maybe :string]]]}}}
+
+  [{:keys [ds user path-params] :as _request}]
+  (-> (services/feed ds {:where [:and
+                                 [:= :id (:id path-params)]
+                                 [:= :user-id (:id user)]]})
+      (res/response)))

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -7,33 +7,30 @@
 
 (defn get
   {:summary "get all feeds"
-   :responses  {200 {:body [:map
-                            [:users
-                             [:vector
-                              [:map
-                               [:id :int]
-                               [:title :string]
-                               [:display-picture [:maybe :string]]
-                               [:url [:maybe :string]]
-                               [:rss-url :string]
-                               [:user-id [:maybe :int]]
-                               [:provider-id [:maybe :int]]
-                               [:created-at :string]
-                               [:updated-at [:maybe :string]]
-                               [:content-type-id :int]
-                               [:cadence-id :int]
-                               [:baseline-id :int]
-                               [:ts-and-cs [:maybe :string]]
-                               [:state [:maybe :string]]]]]]}}}
+   :responses  {200 {:body [:vector
+                            [:map
+                             [:id :int]
+                             [:title :string]
+                             [:display-picture [:maybe :string]]
+                             [:url [:maybe :string]]
+                             [:rss-url :string]
+                             [:user-id [:maybe :int]]
+                             [:provider-id [:maybe :int]]
+                             [:created-at :string]
+                             [:updated-at [:maybe :string]]
+                             [:content-type-id :int]
+                             [:cadence-id :int]
+                             [:baseline-id :int]
+                             [:ts-and-cs [:maybe :string]]
+                             [:state [:maybe :string]]]]}}}
 
   [{:keys [ds user] :as _request}]
   (-> (services/feeds ds {:where [:= :user-id (:id user)]})
       (res/response)))
 
 (defn post
-  {:summary "adds a feed and extracts data from RSS feed URL into a post and schedules a job to keep them updated"
+  {:summary "adds a feed and extracts data from RSS feed URL to create incoming posts and schedules a job to keep them updated"
    :parameters {:body [:map
-                       [:title :string]
                        [:display-picture {:optional true} :string]
                        [:url {:optional true} :string]
                        [:rss-url :string]
@@ -72,33 +69,38 @@
         extracted (when-not (= latest-ss -1)
                     (services/extract-data store {:schema-id latest-ss
                                                   :url rss-url}))
+        extracted-posts (get-in extracted [:feed :posts])
         new-feed (services/insert-feed!
                   ds
-                  {:data (merge body {:user-id (:id user)
+                  {:data (merge body {:title (get-in extracted [:feed :title])
+                                      :user-id (:id user)
                                       :created-at datetime})})
-        new-post (when (some? extracted)
-                   (services/insert-incoming-post! ds {:data (merge extracted
-                                                                    {:feed-id (:id new-feed)
-                                                                     :creator-id (:id user)
-                                                                     :content-type-id content-type-id})}))
+        extended-posts (mapv (fn [post]
+                               (merge post
+                                      {:feed-id (:id new-feed)
+                                       :creator-id (:id user)
+                                       :content-type-id content-type-id})) extracted-posts)
         {:keys [email]} (services/user ds {:id (:id user)})]
 
-    (if (some? extracted)
+    (if (some? extracted-posts)
       (do
+        (services/insert-incoming-post! ds {:data extended-posts})
+
         (->> (jobs/prepare-congest-metadata
               ds
               store
-              {:id (str email "-" (:id new-feed) "-" (:id new-post))
-               :initial-delay (* 1000 60 60 24)
+              {:id (str email "-" (:id new-feed))
+               :initial-delay #_(* 1000 60 60 24) (* 1000 60)
                :auto-start true
                :stop-after-fail false,
-               :interval (* 1000 60 60 24)
+               :interval #_(* 1000 60 60 24) (* 1000 60)
                :recurring? true
                :args {:feed-id (:id new-feed)
-                      :post-id (:id new-post)
-                      :schema-id latest-ss
+                      :creator-id (:id user)
+                      :content-type-id content-type-id
+                      :provider-id provider-id
                       :url rss-url}
-               :handler :update-feed-post
+               :handler :update-feed-posts
                :created-at (utils/get-utc-timestamp-string)
                :sleep false})
              (congest/register! js))
@@ -111,15 +113,15 @@
   (require '[source.db.util :as db.util]
            '[source.datastore.util :as store.util])
 
-  (get {:ds (db.util/conn) :user {:id 5}})
+  (get {:ds (db.util/conn) :user {:id 3}})
   (post {:ds (db.util/conn)
          :js (congest/create-job-service [])
          :store (store.util/conn :datahike)
-         :user {:id 5}
-         :body {:title "primeagen test"
-                :rss-url "https://www.youtube.com/feeds/videos.xml?channel_id=UCUyeluBRhGPCW4rPe_UvBZQ"
+         :user {:id 3}
+         :body {:rss-url "https://www.youtube.com/feeds/videos.xml?channel_id=UCUyeluBRhGPCW4rPe_UvBZQ"
                 :provider-id 1
                 :content-type-id 1
                 :cadence-id 1
                 :baseline-id 1}})
+
   ())

--- a/src/source/routes/posts.clj
+++ b/src/source/routes/posts.clj
@@ -1,0 +1,31 @@
+(ns source.routes.posts
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get all posts by feed id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "feed id"} :int]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:id :int]
+                            [:post-id :string]
+                            [:feed-id :int]
+                            [:creator-id :int]
+                            [:content-type-id :int]
+                            [:title :string]
+                            [:info [:maybe :string]]
+                            [:url [:maybe :string]]
+                            [:stream-url [:maybe :string]]
+                            [:season [:maybe :int]]
+                            [:episode [:maybe :int]]
+                            [:redacted [:maybe :int]]
+                            [:posted-at [:maybe :string]]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds user path-params] :as _request}]
+  (-> (services/incoming-posts ds {:where [:and
+                                           [:= :creator-id (:id user)]
+                                           [:= :feed-id (:id path-params)]]})
+      (res/response)))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -31,6 +31,8 @@
             [source.routes.content-types :as content-types]
             [source.routes.content-type :as content-type]
             [source.routes.feeds :as feeds]
+            [source.routes.feed :as feed]
+            [source.routes.posts :as posts]
             [source.routes.xml :as xml]
             [source.routes.data :as data]
             [source.routes.jobs :as jobs]
@@ -126,7 +128,10 @@
      ["/feeds"          {:middleware [[mw/apply-auth]]
                          :tags #{"feeds"}}
       [""               (route {:get feeds/get
-                                :post feeds/post})]]
+                                :post feeds/post})]
+      ["/:id"
+       [""              (route {:get feed/get})]
+       ["/posts"        (route {:get posts/get})]]]
 
      ["/admin"                  {:middleware [[mw/apply-auth {:required-type :admin}]]
                                  :no-doc true
@@ -442,7 +447,7 @@
         (json/read-json {:key-fn keyword})))
 
   (let [app (create-app components)
-        request {:uri "/admin/jobs/1/manage/deregister"
+        request {:uri "/admin/jobs/8/manage/deregister"
                  :request-method :get
                  :headers {"authorization" (str "Bearer " (auth.util/sign-jwt {:id 1 :type "admin"}))}}]
     (-> request

--- a/src/source/services/incoming_posts.clj
+++ b/src/source/services/incoming_posts.clj
@@ -1,10 +1,10 @@
 (ns source.services.incoming-posts
   (:require [source.db.interface :as db]))
 
-(defn insert-incoming-post! [ds {:keys [data] :as opts}]
+(defn insert-incoming-post! [ds {:keys [data ret] :as opts}]
   (->> {:tname :incoming-posts
         :data data
-        :ret :1}
+        :ret ret}
        (merge opts)
        (db/insert! ds)))
 

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -100,7 +100,7 @@
 (defn feed [ds id]
   (feeds/feed ds id))
 
-(defn insert-incoming-post! [ds {:keys [_data] :as opts}]
+(defn insert-incoming-post! [ds {:keys [_data _ret] :as opts}]
   (incoming-posts/insert-incoming-post! ds opts))
 
 (defn update-incoming-post! [ds {:keys [_id _data _where] :as opts}]


### PR DESCRIPTION
Updated add feed route to pull all posts from the feed and schedule a job that updates existing posts and adds new ones.
Added routes get one or all feeds associated with a creator, and all posts associated with the given feed.
