### PR TITLE
fix datastore path function

### DIFF
--- a/src/source/datastore/config.clj
+++ b/src/source/datastore/config.clj
@@ -10,9 +10,13 @@
       (str path)))
 
 (defn store-path
-  ([store-name]
-   (-> (str (conf/read-value :database :dir) store-name)
-       (absolute))))
+  [store-name]
+  (let [db-dir (conf/read-value :database :dir)]
+    (str
+     db-dir
+     (when (not (= (last db-dir) \/))
+       "/")
+     store-name)))
 
 (defn config [store-name]
   {:store {:backend :file


### PR DESCRIPTION
Fixed datastore path function to correctly handle a database directory without a trailing forward slash. This fix is necessary for the datastore to be created successfully in deployment.
