### PR TITLE
feed review endpoints

### DIFF
--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -69,7 +69,7 @@
    [:display-picture :text]
    [:url :text]
    [:rss-url :text :not nil]
-   [:user-id :integer]
+   [:user-id :integer :not nil]
    [:provider-id :integer]
    [:created-at :datetime :not nil]
    [:updated-at :datetime]
@@ -77,7 +77,7 @@
    [:cadence-id :integer :not nil]
    [:baseline-id :integer :not nil]
    [:ts-and-cs :text]
-   [:state :text]
+   [:state :text [:check [:in :state ["live" "not live" "pending"]]]]
    (tables/foreign-key :user-id :users :id)
    (tables/foreign-key :provider-id :providers :id)
    (tables/foreign-key :cadence-id :cadences :id)

--- a/src/source/routes/admin_feeds.clj
+++ b/src/source/routes/admin_feeds.clj
@@ -11,7 +11,7 @@
                              [:display-picture [:maybe :string]]
                              [:url [:maybe :string]]
                              [:rss-url :string]
-                             [:user-id [:maybe :int]]
+                             [:user-id :int]
                              [:provider-id [:maybe :int]]
                              [:created-at :string]
                              [:updated-at [:maybe :string]]
@@ -19,8 +19,8 @@
                              [:cadence-id :int]
                              [:baseline-id :int]
                              [:ts-and-cs [:maybe :string]]
-                             [:state [:maybe :string]]]]}}}
+                             [:state [:enum "live" "not live" "pending"]]]]}}}
 
   [{:keys [ds] :as _request}]
-    (-> (services/feeds ds)
-        (res/response)))
+  (-> (services/feeds ds)
+      (res/response)))

--- a/src/source/routes/approve_feed.clj
+++ b/src/source/routes/approve_feed.clj
@@ -4,7 +4,7 @@
             [source.email.templates :as templates]
             [ring.util.response :as res]))
 
-(defn patch
+(defn post
   {:summary "approve the feed with the given feed-id and allow it to go live"
    :parameters {:path [:map [:id {:title "id"
                                   :description "feed id"} :int]]}

--- a/src/source/routes/approve_feed.clj
+++ b/src/source/routes/approve_feed.clj
@@ -1,0 +1,26 @@
+(ns source.routes.approve-feed
+  (:require [source.services.interface :as services]
+            [source.email.gmail :as gmail]
+            [source.email.templates :as templates]
+            [ring.util.response :as res]))
+
+(defn patch
+  {:summary "approve the feed with the given feed-id and allow it to go live"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "feed id"} :int]]}
+   :responses {200 {:body [:map [:message :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+  (let [{:keys [id user-id title]} (services/feed ds path-params)
+        {:keys [email firstname]} (services/user ds {:id user-id})]
+    (services/update-feed! ds {:id (:id path-params)
+                               :data {:state "live"}})
+    (gmail/send-email {:to email
+                       :subject "Feed Approval"
+                       :body (templates/feed-approval {:creator-name firstname
+                                                       :feed-title title
+                                                       :feed-id id})
+                       :type :text/html})
+    (res/response {:message "successfully approved feed"})))

--- a/src/source/routes/feed.clj
+++ b/src/source/routes/feed.clj
@@ -12,7 +12,7 @@
                             [:display-picture [:maybe :string]]
                             [:url [:maybe :string]]
                             [:rss-url :string]
-                            [:user-id [:maybe :int]]
+                            [:user-id :int]
                             [:provider-id [:maybe :int]]
                             [:created-at :string]
                             [:updated-at [:maybe :string]]
@@ -20,7 +20,7 @@
                             [:cadence-id :int]
                             [:baseline-id :int]
                             [:ts-and-cs [:maybe :string]]
-                            [:state [:maybe :string]]]}}}
+                            [:state [:enum "live" "not live" "pending"]]]}}}
 
   [{:keys [ds path-params] :as _request}]
   (-> (services/feed ds path-params)

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -14,7 +14,7 @@
                              [:display-picture [:maybe :string]]
                              [:url [:maybe :string]]
                              [:rss-url :string]
-                             [:user-id [:maybe :int]]
+                             [:user-id :int]
                              [:provider-id [:maybe :int]]
                              [:created-at :string]
                              [:updated-at [:maybe :string]]
@@ -22,7 +22,7 @@
                              [:cadence-id :int]
                              [:baseline-id :int]
                              [:ts-and-cs [:maybe :string]]
-                             [:state [:maybe :string]]]]}}}
+                             [:state [:enum "live" "not live" "pending"]]]]}}}
 
   [{:keys [ds user] :as _request}]
   (-> (services/feeds ds {:where [:= :user-id (:id user)]})
@@ -38,15 +38,14 @@
                        [:content-type-id :int]
                        [:cadence-id :int]
                        [:baseline-id :int]
-                       [:ts-and-cs {:optional true} :string]
-                       [:state {:optional true} :string]]}
+                       [:ts-and-cs {:optional true} :string]]}
    :responses {200 {:body [:map
                            [:id :int]
                            [:title :string]
                            [:display-picture [:maybe :string]]
                            [:url [:maybe :string]]
                            [:rss-url :string]
-                           [:user-id [:maybe :int]]
+                           [:user-id :int]
                            [:provider-id [:maybe :int]]
                            [:created-at :string]
                            [:updated-at [:maybe :string]]
@@ -54,7 +53,7 @@
                            [:cadence-id :int]
                            [:baseline-id :int]
                            [:ts-and-cs [:maybe :string]]
-                           [:state [:maybe :string]]]}}}
+                           [:state [:enum "live" "not live" "pending"]]]}}}
 
   [{:keys [js ds store user body] :as _request}]
   (let [{:keys [provider-id rss-url content-type-id]} body
@@ -74,7 +73,8 @@
                   ds
                   {:data (merge body {:title (get-in extracted [:feed :title])
                                       :user-id (:id user)
-                                      :created-at datetime})})
+                                      :created-at datetime
+                                      :state "pending"})})
         extended-posts (mapv (fn [post]
                                (merge post
                                       {:feed-id (:id new-feed)

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -42,6 +42,8 @@
             [source.routes.job-start :as job-start]
             [source.routes.job-stop :as job-stop]
             [source.routes.report :as report]
+            [source.routes.approve-feed :as approve-feed]
+            [source.routes.reject-feed :as reject-feed]
             [source.util :as util]))
 
 (defn route [handlers]
@@ -146,7 +148,10 @@
                                  :swagger {:security [{"auth" []}]}
                                  :openapi {:security [{:bearerAuth []}]}}
       ["/feeds"
-       [""                      (route {:get admin-feeds/get})]]
+       [""                      (route {:get admin-feeds/get})]
+       ["/:id"
+        ["/approve"             (route {:patch approve-feed/patch})]
+        ["/reject"              (route {:patch reject-feed/patch})]]]
       ["/jobs"
        [""                      {:get jobs/get}]
        ["/manage"

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -150,8 +150,8 @@
       ["/feeds"
        [""                      (route {:get admin-feeds/get})]
        ["/:id"
-        ["/approve"             (route {:patch approve-feed/patch})]
-        ["/reject"              (route {:patch reject-feed/patch})]]]
+        ["/approve"             (route {:post approve-feed/post})]
+        ["/reject"              (route {:post reject-feed/post})]]]
       ["/jobs"
        [""                      {:get jobs/get}]
        ["/manage"

--- a/src/source/routes/reject_feed.clj
+++ b/src/source/routes/reject_feed.clj
@@ -1,0 +1,27 @@
+(ns source.routes.reject-feed
+  (:require [source.services.interface :as services]
+            [source.email.gmail :as gmail]
+            [source.email.templates :as templates]
+            [ring.util.response :as res]))
+
+(defn patch
+  {:summary "reject the feed with the given feed-id and prevent it from going live"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "feed id"} :int]]
+                :body [:map [:message :string]]}
+   :responses {200 {:body [:map [:message :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params body] :as _request}]
+  (let [{:keys [user-id title]} (services/feed ds path-params)
+        {:keys [email firstname]} (services/user ds {:id user-id})]
+    (services/update-feed! ds {:id (:id path-params)
+                               :data {:state "not live"}})
+    (gmail/send-email {:to email
+                       :subject "Feed Rejection"
+                       :body (templates/feed-rejection {:creator-name firstname
+                                                        :feed-title title
+                                                        :reason (:message body)})
+                       :type :text/html})
+    (res/response {:message "successfully rejected feed"})))

--- a/src/source/routes/reject_feed.clj
+++ b/src/source/routes/reject_feed.clj
@@ -4,7 +4,7 @@
             [source.email.templates :as templates]
             [ring.util.response :as res]))
 
-(defn patch
+(defn post
   {:summary "reject the feed with the given feed-id and prevent it from going live"
    :parameters {:path [:map [:id {:title "id"
                                   :description "feed id"} :int]]

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -97,8 +97,8 @@
   ([ds {:keys [_where] :as opts}]
    (feeds/feeds ds opts)))
 
-(defn feed [ds id]
-  (feeds/feed ds id))
+(defn feed [ds {:keys [_id] :as opts}]
+  (feeds/feed ds opts))
 
 (defn insert-incoming-post! [ds {:keys [_data _ret] :as opts}]
   (incoming-posts/insert-incoming-post! ds opts))


### PR DESCRIPTION
This PR implements endpoints required for admins to be able to approve or reject feeds. The state of a feed is now an enum consisting of live, not live and pending, instead of just a string. When admins approve or reject a feed, the email service is used to send emails to users regarding the decision.
