### PR TITLE
integration endpoints

### DIFF
--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -8,6 +8,7 @@
      ds-bundle
      :source.db.bundle
      [:outgoing-posts
+      :bundle-categories
       :post-heuristics
       :analytics
       :event-categories])))
@@ -17,6 +18,7 @@
     (tables/drop-tables!
      ds-bundle
      [:outgoing-posts
+      :bundle-categories
       :post-heuristics
       :analytics
       :event-categories])))

--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -14,4 +14,9 @@
 
 (defn run-down! [context]
   (let [ds-bundle (:db-bundle context)]
-    (tables/drop-all-tables! ds-bundle)))
+    (tables/drop-tables!
+     ds-bundle
+     [:outgoing-posts
+      :post-heuristics
+      :analytics
+      :event-categories])))

--- a/src/source/db/bundle.clj
+++ b/src/source/db/bundle.clj
@@ -30,6 +30,15 @@
    (tables/foreign-key :content-type-id :content-types :id)
    [[:unique [:composite :post-id]]]))
 
+(def bundle-categories
+  (tables/create-table-sql
+   :bundle-categories
+   (tables/table-id)
+   [:bundle-id :int :not nil]
+   [:category-id :int :not nil]
+   (tables/foreign-key :bundle-id :bundles :id)
+   (tables/foreign-key :category-id :categories :id)))
+
 (def post-heuristics
   (tables/create-table-sql
    :post-heuristics
@@ -50,6 +59,7 @@
 (comment
   (sql/format event-categories)
   (sql/format outgoing-posts)
+  (sql/format bundle-categories)
   (sql/format post-heuristics)
   (sql/format analytics)
   ())

--- a/src/source/db/bundle.clj
+++ b/src/source/db/bundle.clj
@@ -27,7 +27,8 @@
    [:posted-at :datetime]
    (tables/foreign-key :feed-id :feeds :id)
    (tables/foreign-key :creator-id :users :id)
-   (tables/foreign-key :content-type-id :content-types :id)))
+   (tables/foreign-key :content-type-id :content-types :id)
+   [[:unique [:composite :post-id]]]))
 
 (def post-heuristics
   (tables/create-table-sql
@@ -35,7 +36,8 @@
    (tables/table-id)
    [:post-id :integer :not nil]
    [:long-heuristic :integer]
-   [:short-heuristic :integer]))
+   [:short-heuristic :integer]
+   [[:unique [:composite :post-id]]]))
 
 (def analytics
   (tables/create-table-sql

--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -67,15 +67,6 @@
    (tables/foreign-key :content-type-id :content-types :id)
    (tables/foreign-key :user-id :users :id)))
 
-(def bundle-categories
-  (tables/create-table-sql
-   :bundle-categories
-   (tables/table-id)
-   [:bundle-id :int :not nil]
-   [:category-id :int :not nil]
-   (tables/foreign-key :bundle-id :bundles :id)
-   (tables/foreign-key :category-id :categories :id)))
-
 (def feeds
   (tables/create-table-sql
    :feeds
@@ -211,7 +202,6 @@
   (sql/format categories)
   (sql/format baselines)
   (sql/format bundles)
-  (sql/format bundle-categories)
   (sql/format feeds)
   (sql/format feed-categories)
   (sql/format providers)

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -1,6 +1,9 @@
 (ns source.jobs.handlers
   (:require [source.services.interface :as services]
-            [source.util :as util]))
+            [source.util :as util]
+            [source.services.incoming-posts :as incoming-posts]
+            [source.db.util :as db.util]
+            [clojure.set :as set]))
 
 (defmulti handler
   (fn [opts]
@@ -45,4 +48,52 @@
              (services/insert-incoming-post! ds {:data post})))
          extended-posts))
       (catch Exception _ :fail))))
+
+; run long heuristics and pull the highest scoring incoming posts into the bundle's outgoing posts
+(defmethod handler :update-bundle [_]
+  (fn [{:keys [args ds]}]
+    (println "hello" (get args :bundle-id) args)
+    (let [{:keys [bundle-id categories]} args
+          ds-bundle (db.util/conn :bundle bundle-id)
+          incoming-posts (services/incoming-posts-with-feeds (db.util/conn) {:where [:= :feeds.state "live"]})
+          posts-categories (incoming-posts/categories-by-posts ds {:where [:= :state "live"]})]
+      (run!
+       (fn [post]
+          ; calculate score for post
+          ; determine number of categories matched
+         (let [; get vector of category ids in the given post, e.g. [1 3]
+               post-categories-vec (reduce (fn [acc {:keys [post-id id]}]
+                                             (if (= post-id (:id post))
+                                               (conj acc id)
+                                               acc)) [] posts-categories)
+               ; get vector of category ids in categories to match, e.g. [1 2 3 4]
+               match-categories-vec (reduce (fn [acc {:keys [id]}]
+                                              (conj acc id)) [] categories)
+               ; get number of matches between the 2 vectors, e.g. #{1 3} intersect #{1 2 3 4} -> (count #{1 3}) -> 2
+               matches (count (set/intersection (set post-categories-vec)
+                                                (set match-categories-vec)))]
+            ; use matches as a score and upsert long-heuristic for this post
+           (services/upsert-post-heuristics! ds-bundle {:data [{:post-id (:id post)
+                                                                :long-heuristic matches}]})))
+       incoming-posts)
+
+      ; pull highest scored posts by long heuristics into outgoing posts
+      (let [; top 30 post-heuristics records ordered by long heuristic in descending order
+            top-by-long-heuristics (services/top-posts-by-heuristic ds-bundle
+                                                                    {:heuristic :long-heuristic
+                                                                     :limit 30})
+            ; convert into a vector of id numbers
+            ids (reduce (fn [acc {:keys [id]}]
+                          (conj acc id)) [] top-by-long-heuristics)
+
+            ; get all incoming posts with the above id numbers
+            posts-in (services/incoming-posts ds {:where [:in :id ids]})
+            ; remove redacted posts
+            outgoing-posts (reduce (fn [acc {:keys [redacted] :as post}]
+                                     (if (:= redacted 0)
+                                       (conj acc (dissoc post :redacted))
+                                       acc))
+                                   [] posts-in)]
+        (when (seq posts-in)
+          (services/upsert-outgoing-posts! ds-bundle {:data outgoing-posts}))))))
 

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -52,7 +52,6 @@
 ; run long heuristics and pull the highest scoring incoming posts into the bundle's outgoing posts
 (defmethod handler :update-bundle [_]
   (fn [{:keys [args ds]}]
-    (println "hello" (get args :bundle-id) args)
     (let [{:keys [bundle-id categories]} args
           ds-bundle (db.util/conn :bundle bundle-id)
           incoming-posts (services/incoming-posts-with-feeds (db.util/conn) {:where [:= :feeds.state "live"]})

--- a/src/source/migrate.clj
+++ b/src/source/migrate.clj
@@ -32,26 +32,25 @@
                   :operations migrations}
                  args)))
 
-(defn run-bundle-migrations [args]
-  (let [db-migrate (jdbc/get-datasource {:dbname (db.util/db-path "migrate") :dbtype "sqlite"})
+(defn migrate-bundle [bundle-id args]
+  (let [db-name (db.util/db-name :bundle bundle-id)
+        context {:db-bundle (jdbc/get-datasource {:dbname (db.util/db-path db-name)
+                                                  :dbtype "sqlite"})}
         datastore (store/create-datastore
-                   {:db db-migrate
-                    :table-name "bundle_migrations"})
-        ds-master (db.util/conn :master)
+                   {:db (:db-bundle context)
+                    :table-name "migrations"})]
+    (mallard/run {:context context
+                  :store datastore
+                  :operations bundle-migrations}
+                 args)))
+
+(defn run-bundle-migrations [args]
+  (let [ds-master (db.util/conn :master)
         bundles (if (some #(= % "bundles") (tables/table-names ds-master))
                   (db/find ds-master {:tname :bundles
                                       :ret :*})
                   [])]
-    (run!
-     (fn [{:keys [id]}]
-       (let [db-name (db.util/db-name :bundle id)
-             context {:db-bundle (jdbc/get-datasource {:dbname (db.util/db-path db-name)
-                                                       :dbtype "sqlite"})}]
-         (mallard/run {:context context
-                       :store datastore
-                       :operations bundle-migrations}
-                      args)))
-     bundles)))
+    (run! #(migrate-bundle (:id %) args) bundles)))
 
 (defn -main [& args]
   (run-bundle-migrations args)

--- a/src/source/migrations/001_init_master_db.clj
+++ b/src/source/migrations/001_init_master_db.clj
@@ -78,7 +78,6 @@
       :cadences
       :baselines
       :bundles
-      :bundle-categories
       :feeds
       :feed-categories
       :providers

--- a/src/source/routes/content_type.clj
+++ b/src/source/routes/content_type.clj
@@ -2,7 +2,15 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds path-params] :as _request}]
+(defn get
+  {:summary "get content type by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "content type id"} :int]]}
+   :responses {200 {:body [:map
+                           [:id :int]
+                           [:name :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
   (->> path-params
        (services/content-type ds)
        (res/response)))

--- a/src/source/routes/content_types.clj
+++ b/src/source/routes/content_types.clj
@@ -2,6 +2,13 @@
   (:require [source.services.interface :as services]
             [ring.util.response :as res]))
 
-(defn get [{:keys [ds] :as _request}]
+(defn get
+  {:summary "get all content types"
+   :responses {200 {:body [:vector
+                           [:map
+                            [:id :int]
+                            [:name :string]]]}}}
+
+  [{:keys [ds] :as _request}]
   (-> (services/content-types ds)
       (res/response)))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -1,0 +1,23 @@
+(ns source.routes.integration
+  (:require [ring.util.response :as res]
+            [source.services.interface :as services]))
+
+(defn get
+  {:summary "get integration by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:map
+                           [:name :string]
+                           [:uuid :string]
+                           [:user-id :int]
+                           [:video :int]
+                           [:podcast :int]
+                           [:blog :int]
+                           [:hash [:maybe :string]]
+                           [:content-type-id :int]
+                           [:ts-and-cs [:maybe :int]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+  (res/response (services/bundle ds {:id (:id path-params)})))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -7,6 +7,7 @@
    :parameters {:path [:map [:id {:title "id"
                                   :description "integration id"} :int]]}
    :responses {200 {:body [:map
+                           [:id :int]
                            [:name :string]
                            [:uuid :string]
                            [:user-id :int]

--- a/src/source/routes/integration_categories.clj
+++ b/src/source/routes/integration_categories.clj
@@ -1,6 +1,7 @@
 (ns source.routes.integration-categories
   (:require [source.services.interface :as services]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [source.db.util :as db.util]))
 
 (defn get
   {:summary "get all categories belonging to the integration with the given id"
@@ -9,13 +10,14 @@
    :responses {200 {:body [:vector
                            [:map
                             [:id :int]
-                            [:name :string]
-                            [:bundle-id :int]
-                            [:category-id :int]]]}}}
+                            [:name :string]]]}}}
 
   [{:keys [ds path-params] :as _request}]
-  (->> (services/categories-by-bundle ds {:bundle-id (:id path-params)})
-       (res/response)))
+  (let [bundle-ds (db.util/conn :bundle (:id path-params))
+        category-ids (services/category-id-by-bundle bundle-ds {:bundle-id (:id path-params)})
+        id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)
+        categories (services/categories ds {:where [:in :id id-vec]})]
+    (res/response categories)))
 
 (defn post
   {:summary "update categories belonging to the integration with the given id"

--- a/src/source/routes/integration_categories.clj
+++ b/src/source/routes/integration_categories.clj
@@ -1,0 +1,36 @@
+(ns source.routes.integration-categories
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get all categories belonging to the integration with the given id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:id :int]
+                            [:name :string]
+                            [:bundle-id :int]
+                            [:category-id :int]]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+  (->> (services/categories-by-bundle ds {:bundle-id (:id path-params)})
+       (res/response)))
+
+(defn post
+  {:summary "update categories belonging to the integration with the given id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]
+                :body [:vector
+                       [:map
+                        [:id :int]
+                        [:name :string]]]}
+   :responses {200 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params body] :as _request}]
+  (let [update-data (reduce (fn [acc {:keys [id]}]
+                              (conj acc {:bundle-id (:id path-params)
+                                         :category-id id})) [] body)]
+    (services/delete-bundle-category! ds {:where [:= :integration-id (:id path-params)]})
+    (services/insert-bundle-category! ds {:data update-data})
+    (res/response {:message "successfully updated integration categories"})))

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -11,6 +11,7 @@
   {:summary "get all integrations"
    :responses {200 {:body [:vector
                            [:map
+                            [:id :int]
                             [:name :string]
                             [:uuid :string]
                             [:user-id :int]

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -24,8 +24,8 @@
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
-  [{:keys [ds] :as _request}]
-  (res/response (services/bundles ds)))
+  [{:keys [ds user] :as _request}]
+  (res/response (services/bundles ds {:where [:= :user-id (:id user)]})))
 
 (defn post
   {:summary "add an integration"
@@ -62,10 +62,10 @@
           ds
           store
           {:id (str "bundle_" (:id new-bundle))
-           :initial-delay #_(* 1000 60 60 24) 0
+           :initial-delay (* 1000 60 60 24)
            :auto-start true
            :stop-after-fail false,
-           :interval #_(* 1000 60 60 24) (* 1000 60)
+           :interval (* 1000 60 60 24)
            :recurring? true
            :ds ds
            :args {:bundle-id (:id new-bundle)

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -4,7 +4,8 @@
             [source.util :as utils]
             [source.migrate :as migrate]
             [congest.jobs :as congest]
-            [source.jobs.core :as jobs]))
+            [source.jobs.core :as jobs]
+            [source.db.util :as db.util]))
 
 (defn get
   {:summary "get all integrations"
@@ -45,14 +46,16 @@
                                                        {:user-id (:id user)
                                                         :uuid (utils/uuid)})
                                                 :ret :1})
-        update-data (reduce (fn [acc {:keys [id]}]
-                              (conj acc {:bundle-id (:id new-bundle)
-                                         :category-id id})) [] (:categories body))
+        bundle-categories (reduce (fn [acc {:keys [id]}]
+                                    (conj acc {:bundle-id (:id new-bundle)
+                                               :category-id id})) [] (:categories body))
+        _ (migrate/migrate-bundle (:id new-bundle) ["up"])
         ; insert bundle categories
-        _ (services/insert-bundle-category! ds {:data update-data})
-        categories-by-bundle (services/categories-by-bundle ds {:bundle-id (:id new-bundle)})]
-
-    (migrate/migrate-bundle (:id new-bundle) ["up"])
+        bundle-ds (db.util/conn :bundle (:id new-bundle))
+        _ (services/insert-bundle-category! bundle-ds {:data bundle-categories})
+        category-ids (services/category-id-by-bundle bundle-ds {:bundle-id (:id new-bundle)})
+        id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)
+        categories-by-bundle (services/categories ds {:where [:in :id id-vec]})]
 
     (->> (jobs/prepare-congest-metadata
           ds
@@ -72,4 +75,3 @@
          (congest/register! js))
 
     (res/response {:message "successfully added integration"})))
-

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -1,0 +1,75 @@
+(ns source.routes.integrations
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]
+            [source.util :as utils]
+            [source.migrate :as migrate]
+            [congest.jobs :as congest]
+            [source.jobs.core :as jobs]))
+
+(defn get
+  {:summary "get all integrations"
+   :responses {200 {:body [:vector
+                           [:map
+                            [:name :string]
+                            [:uuid :string]
+                            [:user-id :int]
+                            [:video :int]
+                            [:podcast :int]
+                            [:blog :int]
+                            [:hash [:maybe :string]]
+                            [:content-type-id :int]
+                            [:ts-and-cs [:maybe :int]]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds] :as _request}]
+  (res/response (services/bundles ds)))
+
+(defn post
+  {:summary "add an integration"
+   :parameters {:body [:map
+                       [:name :string]
+                       [:content-type-id :int]
+                       [:ts-and-cs {:optional true} :int]
+                       [:categories [:vector
+                                     [:map
+                                      [:id :int]
+                                      [:name :string]]]]]}
+   :responses {201 {:body [:map [:message :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [js ds store user body] :as _request}]
+  (let [new-bundle (services/insert-bundle! ds {:data (merge
+                                                       (dissoc body :categories)
+                                                       {:user-id (:id user)
+                                                        :uuid (utils/uuid)})
+                                                :ret :1})
+        update-data (reduce (fn [acc {:keys [id]}]
+                              (conj acc {:bundle-id (:id new-bundle)
+                                         :category-id id})) [] (:categories body))
+        ; insert bundle categories
+        _ (services/insert-bundle-category! ds {:data update-data})
+        categories-by-bundle (services/categories-by-bundle ds {:bundle-id (:id new-bundle)})]
+
+    (migrate/migrate-bundle (:id new-bundle) ["up"])
+
+    (->> (jobs/prepare-congest-metadata
+          ds
+          store
+          {:id (str "bundle_" (:id new-bundle))
+           :initial-delay #_(* 1000 60 60 24) 0
+           :auto-start true
+           :stop-after-fail false,
+           :interval #_(* 1000 60 60 24) (* 1000 60)
+           :recurring? true
+           :ds ds
+           :args {:bundle-id (:id new-bundle)
+                  :categories categories-by-bundle}
+           :handler :update-bundle
+           :created-at (utils/get-utc-timestamp-string)
+           :sleep false})
+         (congest/register! js))
+
+    (res/response {:message "successfully added integration"})))
+

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -152,9 +152,9 @@
      ["/baselines"      {:tags #{"baselines"}}
       [""               (route {:get baselines/get})]]
 
-     ["/content-types"  {:tags #{"content types"}}
-      [""               {:get content-types/get}]
-      ["/:id"           {:get content-type/get}]]
+     ["/contentTypes"  {:tags #{"content types"}}
+      [""               (route {:get content-types/get})]
+      ["/:id"           (route {:get content-type/get})]]
 
      ["/integrations"   {:middleware [[mw/apply-auth]]
                          :tags #{"integrations"}}

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -38,6 +38,9 @@
             [source.routes.feeds :as feeds]
             [source.routes.feed :as feed]
             [source.routes.feed-categories :as feed-categories]
+            [source.routes.integrations :as integrations]
+            [source.routes.integration :as integration]
+            [source.routes.integration-categories :as integration-categories]
             [source.routes.posts :as posts]
             [source.routes.admin-feeds :as admin-feeds]
             [source.routes.xml :as xml]
@@ -152,6 +155,15 @@
      ["/content-types"  {:tags #{"content types"}}
       [""               {:get content-types/get}]
       ["/:id"           {:get content-type/get}]]
+
+     ["/integrations"   {:middleware [[mw/apply-auth]]
+                         :tags #{"integrations"}}
+      [""               (route {:get integrations/get
+                                :post integrations/post})]
+      ["/:id"
+       [""              (route {:get integration/get})]
+       ["/categories"   (route {:get integration-categories/get
+                                :post integration-categories/post})]]]
 
      ["/feeds"          {:middleware [[mw/apply-auth]]
                          :tags #{"feeds"}}

--- a/src/source/services/bundle_categories.clj
+++ b/src/source/services/bundle_categories.clj
@@ -40,6 +40,6 @@
         :where (if (some? bundle-id)
                  [:= :bundle-id bundle-id]
                  where)
-        :ret :1}
+        :ret :*}
        (merge opts)
        (db/find ds)))

--- a/src/source/services/incoming_posts.clj
+++ b/src/source/services/incoming_posts.clj
@@ -1,5 +1,6 @@
 (ns source.services.incoming-posts
-  (:require [source.db.interface :as db]))
+  (:require [source.db.interface :as db]
+            [source.db.honey :as hon]))
 
 (defn insert-incoming-post! [ds {:keys [data ret] :as opts}]
   (->> {:tname :incoming-posts
@@ -25,6 +26,16 @@
         (merge opts)
         (db/find ds))))
 
+(defn incoming-posts-with-feeds
+  [ds {:keys [_where] :as opts}]
+  (hon/execute! ds
+                (merge
+                 {:select [[:incoming-posts.id :id] :incoming-posts.post-id :feed-id]
+                  :from :incoming-posts
+                  :join [:feeds [:= :incoming-posts.feed-id :feeds.id]]}
+                 opts)
+                {:ret :*}))
+
 (defn incoming-post [ds {:keys [id where] :as opts}]
   (->> {:tname :incoming-posts
         :where (if (some? id)
@@ -33,3 +44,14 @@
         :ret :1}
        (merge opts)
        (db/find ds)))
+
+(defn categories-by-posts [ds {:keys [_where] :as opts}]
+  (hon/execute! ds
+                (merge
+                 {:select [[:incoming-posts.id :post-id] [:categories.id :id] :categories.name]
+                  :from :incoming-posts
+                  :join [:feeds [:= :incoming-posts.feed-id :feeds.id]]
+                  :left-join [:feed-categories [:= :feed-categories.feed-id :feeds.id]]
+                  :right-join [:categories [:= :categories.id :feed-categories.category-id]]}
+                 opts)
+                {:ret :*}))

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -5,9 +5,11 @@
              [source.services.xml-schemas :as xml]
              [source.services.bundles :as bundles]
              [source.services.bundle-categories :as bundle-categories]
+             [source.services.post-heuristics :as post-heuristics]
              [source.services.providers :as providers]
              [source.services.feeds :as feeds]
              [source.services.incoming-posts :as incoming-posts]
+             [source.services.outgoing-posts :as outgoing-posts]
              [source.services.cadences :as cadences]
              [source.services.baselines :as baselines]
              [source.services.content-types :as content-types]
@@ -62,7 +64,7 @@
 (defn bundles
   ([ds] (bundles ds {}))
   ([ds {:keys [_where] :as opts}]
-   (bundles/bundles opts ds)))
+   (bundles/bundles ds opts)))
 
 (defn bundle [ds {:keys [_id _where] :as opts}]
   (bundles/bundle ds opts))
@@ -83,6 +85,29 @@
 
 (defn category-id-by-bundle [ds {:keys [_bundle-id _where] :as opts}]
   (bundle-categories/category-id ds opts))
+
+(defn insert-post-heuristics! [ds {:keys [_data] :as opts}]
+  (post-heuristics/insert-post-heuristics! ds opts))
+
+(defn update-post-heuristics! [ds {:keys [_id _data _where] :as opts}]
+  (post-heuristics/update-post-heuristics! ds opts))
+
+(defn post-heuristics
+  ([ds] (post-heuristics ds {}))
+  ([ds {:keys [_where] :as opts}]
+   (post-heuristics/post-heuristics ds opts)))
+
+(defn upsert-post-heuristics! [ds {:keys [_data] :as opts}]
+  (post-heuristics/upsert-post-heuristics! ds opts))
+
+(defn post-heuristic [ds {:keys [_id _where] :as opts}]
+  (post-heuristics/post-heuristic ds opts))
+
+(defn top-posts-by-heuristic [ds {:keys [_select _limit _heuristic] :as opts}]
+  (post-heuristics/top-posts-by-heuristic ds opts))
+
+(defn upsert-outgoing-posts! [ds {:keys [_data] :as opts}]
+  (outgoing-posts/upsert-outgoing-posts! ds opts))
 
 (defn selection-schemas
   ([ds]
@@ -155,6 +180,10 @@
    (incoming-posts/incoming-posts ds))
   ([ds {:keys [_where] :as opts}]
    (incoming-posts/incoming-posts ds opts)))
+
+(defn incoming-posts-with-feeds
+  [ds {:keys [_where] :as opts}]
+  (incoming-posts/incoming-posts-with-feeds ds opts))
 
 (defn incoming-post [ds id]
   (incoming-posts/incoming-post ds id))

--- a/src/source/services/outgoing_posts.clj
+++ b/src/source/services/outgoing_posts.clj
@@ -1,6 +1,7 @@
 (ns source.services.outgoing-posts
   (:require [source.db.interface :as db]
-            [source.db.util :as db.util]))
+            [source.db.honey :as hon]
+            [honey.sql.helpers :as hsql]))
 
 (defn outgoing-post [ds {:keys [id where] :as opts}]
   (->> {:tname :outgoing-posts
@@ -11,3 +12,19 @@
        (merge opts)
        (db/find ds)))
 
+(defn upsert-outgoing-posts! [ds {:keys [data]}]
+  (hon/execute!
+   ds
+   (-> (hsql/insert-into :outgoing-posts)
+       (hsql/values data)
+       (assoc :on-conflict [:post-id])
+       (assoc :do-update-set {:feed-id          :excluded.feed-id
+                              :title            :excluded.title
+                              :info             :excluded.info
+                              :url              :excluded.url
+                              :stream-url       :excluded.stream-url
+                              :creator-id       :excluded.creator-id
+                              :season           :excluded.season
+                              :episode          :excluded.episode
+                              :content-type-id  :excluded.content-type-id
+                              :posted-at        :excluded.posted-at}))))

--- a/src/source/services/post_heuristics.clj
+++ b/src/source/services/post_heuristics.clj
@@ -1,0 +1,53 @@
+(ns source.services.post-heuristics
+  (:require [source.db.interface :as db]
+            [source.db.honey :as hon]
+            [honey.sql.helpers :as hsql]))
+
+(defn insert-post-heuristics! [ds {:keys [data] :as opts}]
+  (->> {:tname :post-heuristics
+        :data data
+        :ret :1}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-post-heuristics! [ds {:keys [id _data where] :as opts}]
+  (->> {:tname :post-heuristics
+        :where (if (some? id) [:= :id id] where)
+        :ret :1}
+       (merge opts)
+       (db/update! ds)))
+
+(defn upsert-post-heuristics! [ds {:keys [data]}]
+  (hon/execute!
+   ds
+   (-> (hsql/insert-into :post-heuristics)
+       (hsql/values data)
+       (assoc :on-conflict [:post-id])
+       (assoc :do-update-set {:long-heuristic :excluded.long-heuristic
+                              :short-heuristic :excluded.short-heuristic}))))
+
+(defn post-heuristics
+  ([ds] (post-heuristics ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :post-heuristics
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn top-posts-by-heuristic [ds {:keys [select limit heuristic] :as _opts}]
+  (hon/execute! ds
+                (merge {:select (or select :*)
+                        :from :post-heuristics
+                        :order-by [[heuristic :desc]]
+                        :limit limit})
+                {:ret :*}))
+
+(defn post-heuristic [ds {:keys [id where] :as opts}]
+  (->> {:tname :post-heuristics
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/find ds)))


### PR DESCRIPTION
Added endpoints for getting and adding integrations and integration categories. Adding an integration creates and migrates a bundle database for that integration, then starts a job that pulls the top posts with the most matching categories from incoming posts into the bundle's outgoing posts. This does so by updating the post-heuristics table's long-heuristic field beforehand with just a number of matching categories acting as a score. Posts are pulled in order of their long heuristic, therefore starting with the posts with the most matching categories, down to least. Aside from this, bundle migrations have also been changed in such a way that mallard's oplog are in the bundle databases themselves.
