### PR TITLE
bundle posts endpoints

### DIFF
--- a/src/source/bundle_migrations/002_outgoing_posts.clj
+++ b/src/source/bundle_migrations/002_outgoing_posts.clj
@@ -1,0 +1,16 @@
+(ns source.bundle-migrations.002-outgoing-posts
+  (:require [source.db.bundle]
+            [source.db.tables :as tables]))
+
+(defn run-up! [context]
+  (let [ds-bundle (:db-bundle context)]
+    (tables/create-tables!
+     ds-bundle
+     :source.db.bundle
+     [:outgoing-posts])))
+
+(defn run-down! [context]
+  (let [ds-bundle (:db-bundle context)]
+    (tables/drop-tables!
+     ds-bundle
+     [:outgoing-posts])))

--- a/src/source/db/bundle.clj
+++ b/src/source/db/bundle.clj
@@ -17,6 +17,7 @@
    [:post-id :text :not nil]
    [:feed-id :integer :not nil]
    [:title :text :not nil]
+   [:thumbnail :text]
    [:info :text]
    [:url :text]
    [:stream-url :text]

--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -152,6 +152,7 @@
    [:post-id :text :not nil]
    [:feed-id :integer :not nil]
    [:title :text :not nil]
+   [:thumbnail :text]
    [:info :text]
    [:url :text]
    [:stream-url :text]

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -60,8 +60,8 @@
        (fn [post]
           ; calculate score for post
           ; determine number of categories matched
-         (let [; get vector of category ids in the given post, e.g. [1 3]
-               post-categories-vec (reduce (fn [acc {:keys [post-id id]}]
+              ; get vector of category ids in the given post, e.g. [1 3]
+         (let [post-categories-vec (reduce (fn [acc {:keys [post-id id]}]
                                              (if (= post-id (:id post))
                                                (conj acc id)
                                                acc)) [] posts-categories)
@@ -77,13 +77,12 @@
        incoming-posts)
 
       ; pull highest scored posts by long heuristics into outgoing posts
-      (let [; top 30 post-heuristics records ordered by long heuristic in descending order
-            top-by-long-heuristics (services/top-posts-by-heuristic ds-bundle
+            ; top 30 post-heuristics records ordered by long heuristic in descending order
+      (let [top-by-long-heuristics (services/top-posts-by-heuristic ds-bundle
                                                                     {:heuristic :long-heuristic
-                                                                     :limit 30})
+                                                                     :limit 100})
             ; convert into a vector of id numbers
-            ids (reduce (fn [acc {:keys [id]}]
-                          (conj acc id)) [] top-by-long-heuristics)
+            ids (mapv (fn [{:keys [post-id]}] post-id) top-by-long-heuristics)
 
             ; get all incoming posts with the above id numbers
             posts-in (services/incoming-posts ds {:where [:in :id ids]})
@@ -95,4 +94,3 @@
                                    [] posts-in)]
         (when (seq posts-in)
           (services/upsert-outgoing-posts! ds-bundle {:data outgoing-posts}))))))
-

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -54,17 +54,17 @@
   (fn [{:keys [args ds]}]
     (let [{:keys [bundle-id categories]} args
           ds-bundle (db.util/conn :bundle bundle-id)
-          incoming-posts (services/incoming-posts-with-feeds (db.util/conn) {:where [:= :feeds.state "live"]})
+          incoming-posts (services/incoming-posts-with-feeds ds {:where [:= :feeds.state "live"]})
           posts-categories (incoming-posts/categories-by-posts ds {:where [:= :state "live"]})]
       (run!
        (fn [post]
           ; calculate score for post
           ; determine number of categories matched
               ; get vector of category ids in the given post, e.g. [1 3]
-         (let [post-categories-vec (reduce (fn [acc {:keys [post-id id]}]
-                                             (if (= post-id (:id post))
-                                               (conj acc id)
-                                               acc)) [] posts-categories)
+         (let [post-categories-vec (->> posts-categories
+                                        (mapv (fn [{:keys [post-id id]}]
+                                                (when (= post-id (:id post)) id)))
+                                        (filterv identity))
                ; get vector of category ids in categories to match, e.g. [1 2 3 4]
                match-categories-vec (reduce (fn [acc {:keys [id]}]
                                               (conj acc id)) [] categories)
@@ -82,7 +82,7 @@
                                                                     {:heuristic :long-heuristic
                                                                      :limit 100})
             ; convert into a vector of id numbers
-            ids (mapv (fn [{:keys [post-id]}] post-id) top-by-long-heuristics)
+            ids (mapv :post-id top-by-long-heuristics)
 
             ; get all incoming posts with the above id numbers
             posts-in (services/incoming-posts ds {:where [:in :id ids]})

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -77,7 +77,7 @@
        incoming-posts)
 
       ; pull highest scored posts by long heuristics into outgoing posts
-            ; top 30 post-heuristics records ordered by long heuristic in descending order
+            ; top 100 post-heuristics records ordered by long heuristic in descending order
       (let [top-by-long-heuristics (services/top-posts-by-heuristic ds-bundle
                                                                     {:heuristic :long-heuristic
                                                                      :limit 100})

--- a/src/source/migrations/002_incoming_posts.clj
+++ b/src/source/migrations/002_incoming_posts.clj
@@ -1,0 +1,14 @@
+(ns source.migrations.002-incoming-posts
+  (:require [source.db.master]
+            [source.db.tables :as tables]))
+
+(defn run-up! [context]
+  (let [ds-master (:db-master context)]
+    (tables/create-tables!
+     ds-master
+     :source.db.master
+     [:incoming-posts])))
+
+(defn run-down! [context]
+  (let [ds-master (:db-master context)]
+    (tables/drop-table! ds-master :incoming-posts)))

--- a/src/source/routes/bundle_post.clj
+++ b/src/source/routes/bundle_post.clj
@@ -1,0 +1,31 @@
+(ns source.routes.bundle-post
+  (:require [source.services.interface :as services]
+            [source.db.util :as db.util]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get a single outgoing post in the uuid-authorized bundle by post id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "post id"} :int]]}
+   :responses {200 {:body [:map
+                           [:id :int]
+                           [:post-id :string]
+                           [:feed-id :int]
+                           [:creator-id :int]
+                           [:content-type-id :int]
+                           [:title :string]
+                           [:thumbnail [:maybe :string]]
+                           [:info [:maybe :string]]
+                           [:url [:maybe :string]]
+                           [:stream-url [:maybe :string]]
+                           [:season [:maybe :int]]
+                           [:episode [:maybe :int]]
+                           [:redacted [:maybe :int]]
+                           [:posted-at [:maybe :string]]]}
+               404 {:body [:map [:message :string]]}}}
+
+  [{:keys [bundle-id path-params] :as _request}]
+  (let [bundle-ds (db.util/conn :bundle bundle-id)
+        id (:id path-params)]
+    (res/response (services/outgoing-post bundle-ds {:id id}))))
+

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -1,0 +1,37 @@
+(ns source.routes.bundle-posts
+  (:require [source.services.interface :as services]
+            [source.db.util :as db.util]
+            [clojure.walk :as walk]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get all outgoing posts in the uuid-authorized bundle"
+   :parameters {:query [:map
+                        [:uuid :string]
+                        [:limit :int]
+                        [:start :int]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:id :int]
+                            [:post-id :string]
+                            [:feed-id :int]
+                            [:creator-id :int]
+                            [:content-type-id :int]
+                            [:title :string]
+                            [:thumbnail [:maybe :string]]
+                            [:info [:maybe :string]]
+                            [:url [:maybe :string]]
+                            [:stream-url [:maybe :string]]
+                            [:season [:maybe :int]]
+                            [:episode [:maybe :int]]
+                            [:redacted [:maybe :int]]
+                            [:posted-at [:maybe :string]]]]}
+               404 {:body [:map [:message :string]]}}}
+
+  [{:keys [bundle-id query-params] :as _request}]
+  (let [bundle-ds (db.util/conn :bundle bundle-id)
+        {:keys [limit start]} (walk/keywordize-keys query-params)]
+    (res/response (services/outgoing-posts bundle-ds {:where (when start [:>= :id start])
+                                                      :limit limit
+                                                      :order-by [[:id :asc]]}))))
+

--- a/src/source/routes/posts.clj
+++ b/src/source/routes/posts.clj
@@ -14,6 +14,7 @@
                             [:creator-id :int]
                             [:content-type-id :int]
                             [:title :string]
+                            [:thumbnail [:maybe :string]]
                             [:info [:maybe :string]]
                             [:url [:maybe :string]]
                             [:stream-url [:maybe :string]]

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -41,6 +41,8 @@
             [source.routes.integrations :as integrations]
             [source.routes.integration :as integration]
             [source.routes.integration-categories :as integration-categories]
+            [source.routes.bundle-posts :as bundle-posts]
+            [source.routes.bundle-post :as bundle-post]
             [source.routes.posts :as posts]
             [source.routes.admin-feeds :as admin-feeds]
             [source.routes.xml :as xml]
@@ -176,6 +178,12 @@
        ["/posts"        (route {:get posts/get})]
        ["/categories"   (route {:get feed-categories/get
                                 :post feed-categories/post})]]]
+
+     ["/bundles"        {:middleware [[mw/apply-bundle]]
+                         :tags #{"bundles"}}
+      ["/posts"
+       [""              (route {:get bundle-posts/get})]
+       ["/:id"          (route {:get bundle-post/get})]]]
 
      ["/admin"                  {:middleware [[mw/apply-auth {:required-type :admin}]]
                                  :tags #{"admin"}

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -106,6 +106,14 @@
 (defn top-posts-by-heuristic [ds {:keys [_select _limit _heuristic] :as opts}]
   (post-heuristics/top-posts-by-heuristic ds opts))
 
+(defn outgoing-posts
+  ([ds] (outgoing-posts ds {}))
+  ([ds {:keys [_where] :as opts}]
+   (outgoing-posts/outgoing-posts ds opts)))
+
+(defn outgoing-post [ds {:keys [_id _where] :as opts}]
+  (outgoing-posts/outgoing-post ds opts))
+
 (defn upsert-outgoing-posts! [ds {:keys [_data] :as opts}]
   (outgoing-posts/upsert-outgoing-posts! ds opts))
 

--- a/src/source/services/outgoing_posts.clj
+++ b/src/source/services/outgoing_posts.clj
@@ -3,6 +3,15 @@
             [source.db.honey :as hon]
             [honey.sql.helpers :as hsql]))
 
+(defn outgoing-posts
+  ([ds] (outgoing-posts ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :outgoing-posts
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
 (defn outgoing-post [ds {:keys [id where] :as opts}]
   (->> {:tname :outgoing-posts
         :where (if (some? id)
@@ -20,6 +29,7 @@
        (assoc :on-conflict [:post-id])
        (assoc :do-update-set {:feed-id          :excluded.feed-id
                               :title            :excluded.title
+                              :thumbnail        :excluded.thumbnail
                               :info             :excluded.info
                               :url              :excluded.url
                               :stream-url       :excluded.stream-url


### PR DESCRIPTION
Implemented services for working with outgoing posts and added endpoints for getting all or single outgoing posts from a bundle. These endpoints use the bundle authorization middleware to retrieve the bundle id and allow optional limit and start query parameters to handle pagination. In addition, I've added a thumbnail field to the posts schemas as that wasn't already there.
