### PR TITLE
bundle api key

### DIFF
--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -44,14 +44,17 @@
                (res/status 403))))))
 
 (defn wrap-bundle-id
-  "validates the bundle uuid in the query parameters of the request for 
+  "validates the bundle uuid and API key (bundle hash) in the query parameters of the request for 
   unauthenticated users and attaches the bundle-id to the request"
   [handler]
   (fn [request]
     (let [ds (db.util/conn :master)
           bundle-uuid (get-in request [:query-params "uuid"])
+          bundle-api-key (get-in request [:query-params "key"])
           {:keys [id]} (db/find-one ds {:tname :bundles
-                                        :where [:= :uuid bundle-uuid]})]
+                                        :where [:and
+                                                [:= :uuid bundle-uuid]
+                                                [:= :hash bundle-api-key]]})]
       (if (some? id)
         (-> request
             (assoc :bundle-id id)
@@ -89,15 +92,19 @@
     (println "Test passed"))
 
   (require '[source.util :as utils])
-  (let [garbage-request {:query-params {"uuid" "garbage"}}
+  (let [garbage-request {:query-params {"uuid" "garbage"
+                                        "key" "garbage"}}
         ds (db.util/conn)
         uuid (utils/uuid)
-        bundle-request {:query-params {"uuid" uuid}}
+        api-key (utils/uuid)
+        bundle-request {:query-params {"uuid" uuid
+                                       "key" api-key}}
         test-handler (-> (fn [request]
                            request)
                          (wrap-bundle-id))]
     (bundles/insert-bundle! (db.util/conn :master) {:data {:name (str "test-bundle-" uuid)
                                                            :uuid uuid
+                                                           :hash api-key
                                                            :content-type-id 1
                                                            :video 0
                                                            :podcast 0
@@ -115,8 +122,8 @@
                  (:bundle-id))))
     (println "tests passed")
     (db/delete! ds
-             {:tname :bundles
-              :where [:like :name "test-bundle-%"]
-              :ret :*}))
+                {:tname :bundles
+                 :where [:like :name "test-bundle-%"]
+                 :ret :*}))
 
   ())

--- a/src/source/routes/bundle.clj
+++ b/src/source/routes/bundle.clj
@@ -4,7 +4,9 @@
 
 (defn get
   {:summary "get bundle metadata by authorized uuid"
-   :parameters {:query [:map [:uuid :string]]}
+   :parameters {:query [:map 
+                        [:uuid :string]
+                        [:key :string]]}
    :responses {200 {:body [:map
                            [:id :int]
                            [:name :string]

--- a/src/source/routes/bundle.clj
+++ b/src/source/routes/bundle.clj
@@ -13,7 +13,7 @@
                            [:video :int]
                            [:podcast :int]
                            [:blog :int]
-                           [:hash [:maybe :string]]
+                           [:hash {:optional true} [:maybe :string]]
                            [:content-type-id :int]
                            [:ts-and-cs [:maybe :int]]]}
                404 {:body [:map [:message :string]]}}}

--- a/src/source/routes/bundle_feeds.clj
+++ b/src/source/routes/bundle_feeds.clj
@@ -5,7 +5,9 @@
 
 (defn get
   {:summary "get all feeds present in the bundle authorised by uuid"
-   :parameters {:query [:map [:uuid :string]]}
+   :parameters {:query [:map
+                        [:uuid :string]
+                        [:key :string]]}
    :responses {200 {:body [:vector
                            [:map
                             [:id :int]

--- a/src/source/routes/bundle_post.clj
+++ b/src/source/routes/bundle_post.clj
@@ -5,7 +5,9 @@
 
 (defn get
   {:summary "get a single outgoing post in the uuid-authorized bundle by post id"
-   :parameters {:query [:map [:uuid :string]]
+   :parameters {:query [:map
+                        [:uuid :string]
+                        [:key :string]]
                 :path [:map [:id {:title "id"
                                   :description "post id"} :int]]}
    :responses {200 {:body [:map

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -8,6 +8,7 @@
   {:summary "get all outgoing posts in the uuid-authorized bundle"
    :parameters {:query [:map
                         [:uuid :string]
+                        [:key :string]
                         [:limit {:optional true} :int]
                         [:start {:optional true} :int]]}
    :responses {200 {:body [:vector

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -18,14 +18,16 @@
                            [:video :int]
                            [:podcast :int]
                            [:blog :int]
-                           [:hash [:maybe :string]]
+                           [:hash {:optional true} [:maybe :string]]
                            [:content-type-id :int]
                            [:ts-and-cs [:maybe :int]]]}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
   [{:keys [ds path-params] :as _request}]
-  (res/response (services/bundle ds {:id (:id path-params)})))
+  (res/response (dissoc
+                 (services/bundle ds {:id (:id path-params)})
+                 :hash)))
 
 (defn post
   {:summary "update an integration by id"

--- a/src/source/routes/integration_key.clj
+++ b/src/source/routes/integration_key.clj
@@ -1,0 +1,18 @@
+(ns source.routes.integration-key
+  (:require [source.util :as util]
+            [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn post
+  {:summary "generates an API key for an integration by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:map [:hash :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+  (let [api-key (util/uuid)] ; TODO: make this actually generate a hash for the API key
+    (services/update-bundle! ds {:id (:id path-params)
+                                 :data {:hash api-key}})
+    (res/response {:hash api-key})))

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -18,14 +18,15 @@
                             [:video :int]
                             [:podcast :int]
                             [:blog :int]
-                            [:hash [:maybe :string]]
+                            [:hash {:optional true} [:maybe :string]]
                             [:content-type-id :int]
                             [:ts-and-cs [:maybe :int]]]]}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
   [{:keys [ds user] :as _request}]
-  (res/response (services/bundles ds {:where [:= :user-id (:id user)]})))
+  (let [integrations (services/bundles ds {:where [:= :user-id (:id user)]})]
+    (res/response (mapv #(dissoc % :hash) integrations))))
 
 (defn post
   {:summary "add an integration"
@@ -45,7 +46,6 @@
                            [:video :int]
                            [:podcast :int]
                            [:blog :int]
-                           [:hash {:optional true} [:maybe :string]]
                            [:content-type-id :int]
                            [:ts-and-cs {:optional true} :int]]}
                401 {:body [:map [:message :string]]}
@@ -85,4 +85,4 @@
            :sleep false})
          (congest/register! js))
 
-    (res/response new-bundle)))
+    (res/response (dissoc new-bundle :hash))))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -41,6 +41,7 @@
             [source.routes.integrations :as integrations]
             [source.routes.integration :as integration]
             [source.routes.integration-categories :as integration-categories]
+            [source.routes.integration-key :as integration-key]
             [source.routes.bundle :as bundle]
             [source.routes.bundle-feeds :as bundle-feeds]
             [source.routes.bundle-posts :as bundle-posts]
@@ -168,7 +169,8 @@
        [""              (route {:get integration/get
                                 :post integration/post})]
        ["/categories"   (route {:get integration-categories/get
-                                :post integration-categories/post})]]]
+                                :post integration-categories/post})]
+       ["/key"          (route {:post integration-key/post})]]]
 
      ["/feeds"          {:middleware [[mw/apply-auth]]
                          :tags #{"feeds"}}


### PR DESCRIPTION
This PR adds an endpoint to generate an API key and update the hash field on the bundle table (the generated API key is currently just a uuid, this could be updated to be a hash of some sort). The bundle authorization middleware has also been updated to check the API key alongside the bundle's uuid to authorise the bundle. For security reasons, bundle and integration endpoints have been adjusted to exclude the API key from being returned with bundle metadata.
