### PR TITLE
feed thumbnail fallback

### DIFF
--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -31,14 +31,25 @@
             extracted (services/extract-data store {:schema-id latest-ss
                                                     :url url})
             extracted-posts (get-in extracted [:feed :posts])
-            extended-posts (mapv (fn [post]
+            extracted-display (get-in extracted [:feed :display-picture])
+            extended-posts (mapv (fn [{:keys [thumbnail] :as post}]
                                    (merge post
                                           {:feed-id feed-id
                                            :creator-id creator-id
-                                           :content-type-id content-type-id})) extracted-posts)
-            existing-posts (services/incoming-posts ds {:where [:= :creator-id creator-id]})]
+                                           :content-type-id content-type-id
+                                           :thumbnail (if (and thumbnail
+                                                               (seq thumbnail))
+                                                        thumbnail
+                                                        extracted-display)}))
+                                 extracted-posts)
+            existing-posts (services/incoming-posts ds {:where [:= :creator-id creator-id]})
+            existing-feed (services/feed ds {:id feed-id})]
         (services/update-feed! ds {:id feed-id
                                    :data {:title (get-in extracted [:feed :title])
+                                          :display-picture (if (and (:display-picture existing-feed)
+                                                                    (seq (:display-picture existing-feed)))
+                                                             (:display-picture existing-feed)
+                                                             extracted-display)
                                           :updated-at (util/get-utc-timestamp-string)}})
         (run!
          (fn [post]
@@ -77,10 +88,10 @@
        incoming-posts)
 
       ; pull highest scored posts by long heuristics into outgoing posts
-            ; top 100 post-heuristics records ordered by long heuristic in descending order
+            ; top 1000 post-heuristics records ordered by long heuristic in descending order
       (let [top-by-long-heuristics (services/top-posts-by-heuristic ds-bundle
                                                                     {:heuristic :long-heuristic
-                                                                     :limit 100})
+                                                                     :limit 1000})
             ; convert into a vector of id numbers
             ids (mapv :post-id top-by-long-heuristics)
 
@@ -93,4 +104,5 @@
                                        acc))
                                    [] posts-in)]
         (when (seq posts-in)
-          (services/upsert-outgoing-posts! ds-bundle {:data outgoing-posts}))))))
+          (services/delete-outgoing-post! ds-bundle {})
+          (services/insert-outgoing-post! ds-bundle {:data outgoing-posts}))))))

--- a/src/source/routes/feed_categories.clj
+++ b/src/source/routes/feed_categories.clj
@@ -29,6 +29,7 @@
   (let [update-data (reduce (fn [acc {:keys [id]}]
                               (conj acc {:feed-id (:id path-params)
                                          :category-id id})) [] body)]
-    (services/delete-feed-category! ds {:where [:= :feed-id (:id path-params)]})
-    (services/insert-feed-category! ds {:data update-data})
+    (when (seq update-data)
+      (services/delete-feed-category! ds {:where [:= :feed-id (:id path-params)]})
+      (services/insert-feed-category! ds {:data update-data}))
     (res/response {:message "successfully updated feed categories"})))

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -72,6 +72,7 @@
         new-feed (services/insert-feed!
                   ds
                   {:data (merge body {:title (get-in extracted [:feed :title])
+                                      :display-picture (get-in extracted [:feed :display-picture])
                                       :user-id (:id user)
                                       :created-at datetime
                                       :state "pending"})})
@@ -79,7 +80,9 @@
                                (merge post
                                       {:feed-id (:id new-feed)
                                        :creator-id (:id user)
-                                       :content-type-id content-type-id})) extracted-posts)
+                                       :content-type-id content-type-id
+                                       :thumbnail (or (:thumbnail post) (:display-picture new-feed))}))
+                             extracted-posts)
         {:keys [email]} (services/user ds {:id (:id user)})]
 
     (if (some? extracted-posts)

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -114,6 +114,12 @@
 (defn outgoing-post [ds {:keys [_id _where] :as opts}]
   (outgoing-posts/outgoing-post ds opts))
 
+(defn insert-outgoing-post! [ds {:keys [_values _ret] :as opts}]
+  (outgoing-posts/insert-outgoing-post! ds opts))
+
+(defn delete-outgoing-post! [ds {:keys [_id _where] :as opts}]
+  (outgoing-posts/delete-outgoing-post! ds opts))
+
 (defn upsert-outgoing-posts! [ds {:keys [_data] :as opts}]
   (outgoing-posts/upsert-outgoing-posts! ds opts))
 

--- a/src/source/services/outgoing_posts.clj
+++ b/src/source/services/outgoing_posts.clj
@@ -21,6 +21,20 @@
        (merge opts)
        (db/find ds)))
 
+(defn insert-outgoing-post! [ds {:keys [_values _ret] :as opts}]
+  (->> {:tname :outgoing-posts}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn delete-outgoing-post! [ds {:keys [id where] :as opts}]
+  (->> {:tname :outgoing-posts
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))
+
 (defn upsert-outgoing-posts! [ds {:keys [data]}]
   (hon/execute!
    ds


### PR DESCRIPTION
Updated feed insertion and update job to pull display pictures from RSS feeds and use them as a backup for thumbnails if they aren't set. The job will only pull a display picture for the feed if one isn't already set - this way, the user can still manually set a display picture once display image support is finished.
