### PR TITLE
api key implementation

### DIFF
--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -4,7 +4,8 @@
             [ring.util.response :as res]
             [source.services.users :as users]
             [source.services.bundles :as bundles]
-            [source.db.honey :as db]))
+            [source.db.honey :as db]
+            [source.services.interface :as services]))
 
 (defn create-session [user]
   (let [payload {:id (:id user)
@@ -57,8 +58,25 @@
             (assoc :bundle-id id)
             (handler))
         (->
-         (res/response {:message "The bundle you are looking for does not exist"})
+         (res/response {:message "The bundle you are looking for does not exist."})
          (res/status 404))))))
+
+(defn wrap-auth-api-key
+  "validates the api key from the Authorization header for unauthenticated 
+  users and attaches the bundle-id to the request"
+  [handler]
+  (fn [request]
+    (let [ds (db.util/conn :master)
+          {:keys [bundle-id user-id]} (validate-request request)
+          existing-bundle (services/bundle ds {:where [:and
+                                                       [:= :id bundle-id]
+                                                       [:= :user-id user-id]]})]
+      (if (some? existing-bundle)
+        (-> request
+            (assoc :bundle-id bundle-id)
+            (handler))
+        (-> (res/response {:message "The bundle you are looking for does not exist."})
+            (res/status 404))))))
 
 (comment
   (let [authed-request {:headers {"Authorization"
@@ -115,8 +133,8 @@
                  (:bundle-id))))
     (println "tests passed")
     (db/delete! ds
-             {:tname :bundles
-              :where [:like :name "test-bundle-%"]
-              :ret :*}))
+                {:tname :bundles
+                 :where [:like :name "test-bundle-%"]
+                 :ret :*}))
 
   ())

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -4,8 +4,7 @@
             [ring.util.response :as res]
             [source.services.users :as users]
             [source.services.bundles :as bundles]
-            [source.db.honey :as db]
-            [source.services.interface :as services]))
+            [source.db.honey :as db]))
 
 (defn create-session [user]
   (let [payload {:id (:id user)
@@ -68,9 +67,9 @@
   (fn [request]
     (let [ds (db.util/conn :master)
           {:keys [bundle-id user-id]} (validate-request request)
-          existing-bundle (services/bundle ds {:where [:and
-                                                       [:= :id bundle-id]
-                                                       [:= :user-id user-id]]})]
+          existing-bundle (bundles/bundle ds {:where [:and
+                                                      [:= :id bundle-id]
+                                                      [:= :user-id user-id]]})]
       (if (some? existing-bundle)
         (-> request
             (assoc :bundle-id bundle-id)

--- a/src/source/middleware/core.clj
+++ b/src/source/middleware/core.clj
@@ -23,7 +23,7 @@
         (assoc :store store)
         (handler))))
 
-(defn wrap-js 
+(defn wrap-js
   "attaches the provided job service to the handler's request"
   [handler js]
   (fn [request]
@@ -39,7 +39,7 @@
   (-> app
       (wrap-store store)))
 
-(defn apply-js 
+(defn apply-js
   "middleware for attaching the job service to the request"
   [app js]
   (-> app
@@ -96,3 +96,7 @@
 (defn apply-bundle [app]
   (-> app
       (auth/wrap-bundle-id)))
+
+(defn apply-api-key [app]
+  (-> app
+      (auth/wrap-auth-api-key)))

--- a/src/source/middleware/interface.clj
+++ b/src/source/middleware/interface.clj
@@ -11,3 +11,6 @@
 
 (defn apply-bundle [app]
   (mw/apply-bundle app))
+
+(defn apply-api-key [app]
+  (mw/apply-api-key app))

--- a/src/source/routes/integration_key.clj
+++ b/src/source/routes/integration_key.clj
@@ -1,0 +1,16 @@
+(ns source.routes.integration-key
+  (:require [source.middleware.auth.util :as auth.util]
+            [ring.util.response :as res]))
+
+(defn post
+  {:summary "generate an API key for the integration with the given id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:map [:key :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [user path-params] :as _request}]
+  (let [api-key (auth.util/sign-jwt {:user-id (:id user)
+                                     :bundle-id (:id path-params)})]
+    (res/response {:key api-key})))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -40,6 +40,7 @@
             [source.routes.feed-categories :as feed-categories]
             [source.routes.integrations :as integrations]
             [source.routes.integration :as integration]
+            [source.routes.integration-key :as integration-key]
             [source.routes.integration-categories :as integration-categories]
             [source.routes.bundle :as bundle]
             [source.routes.bundle-feeds :as bundle-feeds]
@@ -171,6 +172,7 @@
       ["/:id"
        [""              (route {:get integration/get
                                 :post integration/post})]
+       ["/key"          (route {:post integration-key/post})]
        ["/categories"   (route {:get integration-categories/get
                                 :post integration-categories/post})]]]
 


### PR DESCRIPTION
Implemented JWT based API keys that distributors can use for their integrations. The intended usage is that a distributor will generate a key for which they will be responsible keeping. They will be able to generate a new key when needed and this needs to invalidate the previous key using a version roll-over; however, this is not yet implemented. See ticket: https://github.com/modulr-software/source-be/issues/120

The distributor will need to attach this API key to the Authorization header as a Bearer Token when making requests to outgoing endpoints; middleware has been implemented to handle this.
