### PR TITLE
removed unique attribute from outgoing posts

### DIFF
--- a/src/source/db/bundle.clj
+++ b/src/source/db/bundle.clj
@@ -28,8 +28,7 @@
    [:posted-at :datetime]
    (tables/foreign-key :feed-id :feeds :id)
    (tables/foreign-key :creator-id :users :id)
-   (tables/foreign-key :content-type-id :content-types :id)
-   [[:unique [:composite :post-id]]]))
+   (tables/foreign-key :content-type-id :content-types :id)))
 
 (def bundle-categories
   (tables/create-table-sql

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -120,9 +120,6 @@
 (defn delete-outgoing-post! [ds {:keys [_id _where] :as opts}]
   (outgoing-posts/delete-outgoing-post! ds opts))
 
-(defn upsert-outgoing-posts! [ds {:keys [_data] :as opts}]
-  (outgoing-posts/upsert-outgoing-posts! ds opts))
-
 (defn selection-schemas
   ([ds]
    (selection-schemas ds {}))

--- a/src/source/services/outgoing_posts.clj
+++ b/src/source/services/outgoing_posts.clj
@@ -34,21 +34,3 @@
         :ret :1}
        (merge opts)
        (db/delete! ds)))
-
-(defn upsert-outgoing-posts! [ds {:keys [data]}]
-  (hon/execute!
-   ds
-   (-> (hsql/insert-into :outgoing-posts)
-       (hsql/values data)
-       (assoc :on-conflict [:post-id])
-       (assoc :do-update-set {:feed-id          :excluded.feed-id
-                              :title            :excluded.title
-                              :thumbnail        :excluded.thumbnail
-                              :info             :excluded.info
-                              :url              :excluded.url
-                              :stream-url       :excluded.stream-url
-                              :creator-id       :excluded.creator-id
-                              :season           :excluded.season
-                              :episode          :excluded.episode
-                              :content-type-id  :excluded.content-type-id
-                              :posted-at        :excluded.posted-at}))))


### PR DESCRIPTION
Removed unique attribute from the outgoing posts table and also removed the unused upsert service for outgoing posts.
