### PR TITLE
integration content types

### DIFF
--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -67,6 +67,15 @@
    (tables/foreign-key :content-type-id :content-types :id)
    (tables/foreign-key :user-id :users :id)))
 
+(def bundle-content-types
+  (tables/create-table-sql
+   :bundle-content-types
+   (tables/table-id)
+   [:bundle-id :integer :not nil]
+   [:content-type-id :integer :not nil]
+   (tables/foreign-key :bundle-id :bundles :id)
+   (tables/foreign-key :content-type-id :content-types :id)))
+
 (def feeds
   (tables/create-table-sql
    :feeds
@@ -203,6 +212,7 @@
   (sql/format categories)
   (sql/format baselines)
   (sql/format bundles)
+  (sql/format bundle-content-types)
   (sql/format feeds)
   (sql/format feed-categories)
   (sql/format providers)

--- a/src/source/migrations/003_bundle_content_types.clj
+++ b/src/source/migrations/003_bundle_content_types.clj
@@ -1,0 +1,14 @@
+(ns source.migrations.003-bundle-content-types
+  (:require [source.db.master]
+            [source.db.tables :as tables]))
+
+(defn run-up! [context]
+  (let [ds-master (:db-master context)]
+    (tables/create-tables!
+     ds-master
+     :source.db.master
+     [:bundle-content-types])))
+
+(defn run-down! [context]
+  (let [ds-master (:db-master context)]
+    (tables/drop-table! ds-master :bundle-content-types)))

--- a/src/source/migrations/003_bundle_content_types.clj
+++ b/src/source/migrations/003_bundle_content_types.clj
@@ -1,14 +1,30 @@
 (ns source.migrations.003-bundle-content-types
   (:require [source.db.master]
-            [source.db.tables :as tables]))
+            [source.db.tables :as tables]
+            [source.services.interface :as services]))
 
 (defn run-up! [context]
-  (let [ds-master (:db-master context)]
+  (let [ds-master (:db-master context)
+        bundles (services/bundles ds-master)]
+
     (tables/create-tables!
      ds-master
      :source.db.master
-     [:bundle-content-types])))
+     [:bundle-content-types])
+
+    (run! (fn [{:keys [id content-type-id]}]
+            (when (some? content-type-id)
+              (services/insert-bundle-content-types! ds-master {:data {:bundle-id id
+                                                                       :content-type-id content-type-id}})))
+          bundles)))
 
 (defn run-down! [context]
-  (let [ds-master (:db-master context)]
+  (let [ds-master (:db-master context)
+        bundle-content-types (services/bundles ds-master)]
+
+    (run! (fn [{:keys [bundle-id content-type-id]}]
+            (services/update-bundle! ds-master {:id bundle-id
+                                                :data {:content-type-id content-type-id}}))
+          bundle-content-types)
+
     (tables/drop-table! ds-master :bundle-content-types)))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -20,12 +20,18 @@
                            [:blog :int]
                            [:hash [:maybe :string]]
                            [:content-type-id :int]
-                           [:ts-and-cs [:maybe :int]]]}
+                           [:ts-and-cs [:maybe :int]]
+                           [:content-types [:vector
+                                            [:map
+                                             [:id :int]
+                                             [:name :string]]]]]}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
   [{:keys [ds path-params] :as _request}]
-  (res/response (services/bundle ds {:id (:id path-params)})))
+  (let [integration (services/bundle ds {:id (:id path-params)})
+        content-types (services/content-types-by-bundle ds {:bundle-id (:id path-params)})]
+    (res/response (assoc integration :content-types content-types))))
 
 (defn post
   {:summary "update an integration by id"
@@ -33,7 +39,10 @@
                                   :description "integration id"} :int]]
                 :body [:map
                        [:name :string]
-                       [:content-type-id :int]
+                       [:content-types [:vector
+                                        [:map
+                                         [:id :int]
+                                         [:name :string]]]]
                        [:categories [:vector
                                      [:map
                                       [:id :int]
@@ -44,17 +53,25 @@
 
   [{:keys [js ds store path-params body] :as _request}]
   (let [_ (services/update-bundle! ds {:id (:id path-params)
-                                       :data (dissoc body :categories)})
+                                       :data (dissoc body :categories :content-types)})
 
         bundle-categories (mapv (fn [{:keys [id]}]
                                   {:bundle-id (:id path-params)
                                    :category-id id}) (:categories body))
+        bundle-content-types (mapv (fn [{:keys [id]}]
+                                     {:bundle-id (:id path-params)
+                                      :content-type-id id}) (:content-types body))
+
         job-id (str "bundle_" (:id path-params))
 
         ; update bundle categories
         bundle-ds (db.util/conn :bundle (:id path-params))
         _ (services/delete-bundle-category! bundle-ds {:where [:= :bundle-id (:id path-params)]})
         _ (services/insert-bundle-category! bundle-ds {:data bundle-categories})
+
+        ; update bundle content types
+        _ (services/delete-bundle-content-types! ds {:where [:= :bundle-id (:id path-params)]})
+        _ (services/insert-bundle-content-types! ds {:data bundle-content-types})
 
         category-ids (services/category-id-by-bundle bundle-ds {:bundle-id (:id path-params)})
         id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -31,8 +31,11 @@
   {:summary "add an integration"
    :parameters {:body [:map
                        [:name :string]
-                       [:content-type-id :int]
                        [:ts-and-cs {:optional true} :int]
+                       [:content-types [:vector
+                                        [:map
+                                         [:id :int]
+                                         [:name :string]]]]
                        [:categories [:vector
                                      [:map
                                       [:id :int]
@@ -53,17 +56,25 @@
 
   [{:keys [js ds store user body] :as _request}]
   (let [new-bundle (services/insert-bundle! ds {:data (merge
-                                                       (dissoc body :categories)
+                                                       (dissoc body :categories :content-types)
                                                        {:user-id (:id user)
+                                                        :content-type-id 1 ; temporarily assign garbo id
                                                         :uuid (utils/uuid)})
                                                 :ret :1})
-        bundle-categories (reduce (fn [acc {:keys [id]}]
-                                    (conj acc {:bundle-id (:id new-bundle)
-                                               :category-id id})) [] (:categories body))
+        bundle-categories (mapv (fn [{:keys [id]}]
+                                  {:bundle-id (:id new-bundle)
+                                   :category-id id}) (:categories body))
+        bundle-content-types (mapv (fn [{:keys [id]}]
+                                     {:bundle-id (:id new-bundle)
+                                      :content-type-id id}) (:content-types body))
+
         _ (migrate/migrate-bundle (:id new-bundle) ["up"])
         ; insert bundle categories
         bundle-ds (db.util/conn :bundle (:id new-bundle))
+
         _ (services/insert-bundle-category! bundle-ds {:data bundle-categories})
+        _ (services/insert-bundle-content-types! ds {:data bundle-content-types})
+
         category-ids (services/category-id-by-bundle bundle-ds {:bundle-id (:id new-bundle)})
         id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)
         categories-by-bundle (services/categories ds {:where [:in :id id-vec]})]

--- a/src/source/services/bundle_content_types.clj
+++ b/src/source/services/bundle_content_types.clj
@@ -1,0 +1,45 @@
+(ns source.services.bundle-content-types
+  (:require [source.db.interface :as db]
+            [source.db.honey :as hon]))
+
+(defn bundle-content-types
+  ([ds] (bundle-content-types ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :bundle-content-types
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn insert-bundle-content-types! [ds {:keys [_data _ret] :as opts}]
+  (->> {:tname :bundle-content-types}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn delete-bundle-content-types! [ds {:keys [id where] :as opts}]
+  (->> {:tname :bundle-content-types
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))
+
+(defn content-types-by-bundle [ds {:keys [bundle-id where] :as _opts}]
+  (hon/execute! ds
+                {:select [[:bundle-content-types.content-type-id :id] :name]
+                 :from :content-types
+                 :join [:bundle-content-types [:= :bundle-content-types.content-type-id :content-types.id]]
+                 :where (if (some? bundle-id)
+                          [:= :bundle-id bundle-id]
+                          where)}
+                {:ret :*}))
+
+(defn content-type-id [ds {:keys [bundle-id where] :as opts}]
+  (->> {:tname :bundle-content-types
+        :where (if (some? bundle-id)
+                 [:= :bundle-id bundle-id]
+                 where)
+        :ret :*}
+       (merge opts)
+       (db/find ds)))

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -5,6 +5,7 @@
              [source.services.xml-schemas :as xml]
              [source.services.bundles :as bundles]
              [source.services.bundle-categories :as bundle-categories]
+             [source.services.bundle-content-types :as bundle-content-types]
              [source.services.post-heuristics :as post-heuristics]
              [source.services.providers :as providers]
              [source.services.feeds :as feeds]
@@ -85,6 +86,23 @@
 
 (defn category-id-by-bundle [ds {:keys [_bundle-id _where] :as opts}]
   (bundle-categories/category-id ds opts))
+
+(defn bundle-content-types
+  ([ds] (bundle-content-types ds {}))
+  ([ds {:keys [_where] :as opts}]
+   (bundle-content-types/bundle-content-types ds opts)))
+
+(defn insert-bundle-content-types! [ds {:keys [_data _ret] :as opts}]
+  (bundle-content-types/insert-bundle-content-types! ds opts))
+
+(defn delete-bundle-content-types! [ds {:keys [_id _where] :as opts}]
+  (bundle-content-types/delete-bundle-content-types! ds opts))
+
+(defn content-types-by-bundle [ds {:keys [_bundle-id _where] :as opts}]
+  (bundle-content-types/content-types-by-bundle ds opts))
+
+(defn content-type-id [ds {:keys [_bundle-id _where] :as opts}]
+  (bundle-content-types/content-type-id ds opts))
 
 (defn insert-post-heuristics! [ds {:keys [_data] :as opts}]
   (post-heuristics/insert-post-heuristics! ds opts))


### PR DESCRIPTION
Due to the bundles table in master previously only containing a single content type id, I've added a new table to support multiple content types with a migration for this table and services to work with it. I have updated our integration endpoints to adopt this as well.