### PR TITLE
fix substack post images

### DIFF
--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -3,7 +3,8 @@
             [source.util :as util]
             [source.services.incoming-posts :as incoming-posts]
             [source.db.util :as db.util]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [clojure.string :as string]))
 
 (defmulti handler
   (fn [opts]
@@ -38,7 +39,8 @@
                                            :creator-id creator-id
                                            :content-type-id content-type-id
                                            :thumbnail (if (and thumbnail
-                                                               (seq thumbnail))
+                                                               (seq thumbnail)
+                                                               (not (string/includes? thumbnail ".mp3")))
                                                         thumbnail
                                                         extracted-display)}))
                                  extracted-posts)


### PR DESCRIPTION
Some substack posts don't include an image and instead have an mp3 in its place for a voice-over. In this case, the image is pulled as an mp3 which obviously doesn't work. This is a quick rudimentary fix for this strange behaviour, simply checking if the URL contains a .mp3. In future we could check for this on the frontend and also display a media player button for this stream URL, but that is out of scope right now. We can make a ticket for this.
