### PR TITLE
add-missing-category-route

### DIFF
--- a/src/source/routes/category.clj
+++ b/src/source/routes/category.clj
@@ -1,0 +1,14 @@
+(ns source.routes.category
+  (:require [ring.util.response :as res]
+            [source.services.interface :as services]))
+
+(defn get
+  {:summary "get category by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "category id"} :int]]}
+   :responses {200 {:body [:map
+                           [:id :int]
+                           [:name :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+  (res/response (services/category ds path-params)))


### PR DESCRIPTION
I forgot to actually commit the category-id route file in the previous PR like a dumbass. Here it is now.
