### PR TITLE
latest filter

### DIFF
--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -33,11 +33,12 @@
                                                     :url url})
             extracted-posts (get-in extracted [:feed :posts])
             extracted-display (get-in extracted [:feed :display-picture])
-            extended-posts (mapv (fn [{:keys [thumbnail] :as post}]
+            extended-posts (mapv (fn [{:keys [posted-at thumbnail] :as post}]
                                    (merge post
                                           {:feed-id feed-id
                                            :creator-id creator-id
                                            :content-type-id content-type-id
+                                           :posted-at (util/format-rfc-1123-date posted-at)
                                            :thumbnail (if (and thumbnail
                                                                (seq thumbnail)
                                                                (not (string/includes? thumbnail ".mp3")))

--- a/src/source/routes/bundle_feeds.clj
+++ b/src/source/routes/bundle_feeds.clj
@@ -32,13 +32,14 @@
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [bundle-ds (db.util/conn :bundle bundle-id)
         {:keys [category-ids]} body
-        {:keys [type]} (walk/keywordize-keys query-params)
+        {:keys [type latest]} (walk/keywordize-keys query-params)
         feed-ids (mapv :feed-id (services/outgoing-posts bundle-ds))
         category-filtered-feed-ids (if (empty? category-ids)
                                      feed-ids
                                      (->> (hsql/where
                                            [:in :feed-id feed-ids]
                                            [:in :category-id category-ids])
+                                          (hsql/order-by (when latest [:created-at :desc]))
                                           (services/feed-categories ds)
                                           (mapv :feed-id)))
         type-filtered (->> (when type [:= :content-type-id type])

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -12,7 +12,8 @@
                         [:uuid :string]
                         [:limit {:optional true} :int]
                         [:start {:optional true} :int]
-                        [:type {:optional true} :int]]}
+                        [:type {:optional true} :int]
+                        [:latest {:optional true} [:enum "true" "false"]]]}
    :responses {200 {:body [:vector
                            [:map
                             [:id :int]
@@ -33,14 +34,15 @@
 
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [bundle-ds (db.util/conn :bundle bundle-id)
-        {:keys [limit start type]} (walk/keywordize-keys query-params)
+        {:keys [limit start type latest]} (walk/keywordize-keys query-params)
         {:keys [category-ids]} body
 
         content-type-comp (when type [:= :content-type-id type])
         start (when start (try (Integer/parseInt start) (catch Exception _)))
         limit (when limit (try (Integer/parseInt limit) (catch Exception _)))
 
-        filtered-posts (shuffle (services/outgoing-posts bundle-ds {:where content-type-comp}))
+        filtered-posts (services/outgoing-posts bundle-ds {:where content-type-comp
+                                                           :order-by (when (= latest "true") [[:posted-at :desc]])})
 
         categorised-posts (vec (if (seq category-ids)
                                  (->> filtered-posts

--- a/src/source/util.clj
+++ b/src/source/util.clj
@@ -62,6 +62,17 @@
                                    (m/explain schema)
                                    (me/humanize)))}))
 
+(defn format-rfc-1123-date
+  "Takes a date as a string in RFC 1123 format and returns it in a format that meets ISO 8601 standards for SQLite. 
+  Returns the original string if it is not in this format."
+  [s]
+  (try
+    (let [zdt (java.time.ZonedDateTime/parse s java.time.format.DateTimeFormatter/RFC_1123_DATE_TIME)
+          zdt-utc (.withZoneSameInstant zdt (java.time.ZoneId/of "UTC"))
+          out (.format zdt-utc (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss"))]
+      out)
+    (catch Exception _ s)))
+
 (comment
   (require '[source.routes.business :as business])
   (validate business/post {:cheese "modulr"})

--- a/src/source/util.clj
+++ b/src/source/util.clj
@@ -62,8 +62,9 @@
                                    (m/explain schema)
                                    (me/humanize)))}))
 
-(defn format-rfc-1123-date
-  "Takes a date as a string in RFC 1123 format and returns it in a format that meets ISO 8601 standards for SQLite. 
+(defn format-rss-date
+  "Takes a date as a string in RFC 1123 format and returns it in a format that meets ISO 8601 standards for SQLite.
+  This is necessary because some RSS feeds use a different date than what is accepted by SQLite.
   Returns the original string if it is not in this format."
   [s]
   (try


### PR DESCRIPTION
Added latest filter as an optional query parameter to bundle endpoints for pulling the latest feeds and posts. 

I also included a function to convert date formats in the feed-post-update job. I did this because I encountered some issues with ORDER BY due to some dates pulled from podcasts and articles being in a different date format than what is expected by SQLite.