### PR TITLE
outgoing endpoints

### DIFF
--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -38,7 +38,7 @@
                                           {:feed-id feed-id
                                            :creator-id creator-id
                                            :content-type-id content-type-id
-                                           :posted-at (util/format-rfc-1123-date posted-at)
+                                           :posted-at (util/format-rss-date posted-at)
                                            :thumbnail (if (and thumbnail
                                                                (seq thumbnail)
                                                                (not (string/includes? thumbnail ".mp3")))

--- a/src/source/routes/bundle_feeds.clj
+++ b/src/source/routes/bundle_feeds.clj
@@ -39,11 +39,11 @@
                                      (->> (hsql/where
                                            [:in :feed-id feed-ids]
                                            [:in :category-id category-ids])
-                                          (hsql/order-by (when latest [:created-at :desc]))
                                           (services/feed-categories ds)
                                           (mapv :feed-id)))
-        type-filtered (->> (when type [:= :content-type-id type])
-                           (hsql/where [:in :id category-filtered-feed-ids])
-                           (services/feeds ds))]
+        query (-> (when type [:= :content-type-id type])
+                  (hsql/where [:in :id category-filtered-feed-ids])
+                  (hsql/order-by (when latest [:created-at :desc])))
+        type-filtered (services/feeds ds query)]
 
     (res/response type-filtered)))

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -24,8 +24,8 @@
                              [:ts-and-cs [:maybe :int]]
                              [:state [:enum "live" "not live" "pending"]]]]}}}
 
-  [{:keys [ds] :as _request}]
-  (-> (services/feeds ds)
+  [{:keys [ds user] :as _request}]
+  (-> (services/feeds ds {:where [:= :user-id (:id user)]})
       (res/response)))
 
 (defn post

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -212,6 +212,28 @@
        [""              (route {:post bundle-posts/post})]
        ["/:id"          (route {:get bundle-post/get})]]]
 
+     ["/api"             {:middleware [[mw/apply-api-key]]
+                          :tags #{"api"}
+                          :swagger {:security [{"apiKey" []}]}
+                          :openapi {:security [{:apiKey []}]}}
+      ["/bundle"         {:middleware [[mw/apply-bundle]]}
+       [""               (route {:get bundle/get})]
+       ["/categories"
+        [""              (route {:get bundle-categories/get})]]
+       ["/feeds"
+        [""              (route {:post bundle-feeds/post})]
+        ["/:id"
+         [""             (route {:get bundle-feed/get})]
+         ["/posts"
+          [""            (route {:get bundle-feed-posts/get})]
+          ["/:post-id"   (route {:get bundle-feed-post/get})]]]]
+       ["/posts"
+        [""              (route {:post bundle-posts/post})]
+        ["/:id"          (route {:get bundle-post/get})]]]
+      ["/categories"
+       [""               (route {:get categories/get})]
+       ["/:id"           (route {:get category/get})]]]
+
      ["/admin"                  {:middleware [[mw/apply-auth {:required-type :admin}]]
                                  :tags #{"admin"}
                                  :swagger {:security [{"auth" []}]}


### PR DESCRIPTION
Added set of endpoints using API key authorization middleware as outgoing endpoints. They contain endpoints that point to already existing handlers and, from my understanding, covers all use cases.

I also noticed 2 small bugs that seemed to slip by me earlier that I fixed in this PR (feeds endpoint & feed-post-update handler).
