### PR TITLE
creator post pruning

### DIFF
--- a/src/source/routes/post.clj
+++ b/src/source/routes/post.clj
@@ -1,0 +1,46 @@
+(ns source.routes.post
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "get post by id"
+   :parameters {:path [:map [:post-id {:title "post-id"
+                                       :description "post id"} :int]]}
+   :responses  {200 {:body [:map
+                            [:id :int]
+                            [:post-id :string]
+                            [:feed-id :int]
+                            [:creator-id :int]
+                            [:content-type-id :int]
+                            [:title :string]
+                            [:thumbnail [:maybe :string]]
+                            [:info [:maybe :string]]
+                            [:url [:maybe :string]]
+                            [:stream-url [:maybe :string]]
+                            [:season [:maybe :int]]
+                            [:episode [:maybe :int]]
+                            [:redacted {:optional true} [:maybe :int]]
+                            [:posted-at [:maybe :string]]]}}}
+
+  [{:keys [ds user path-params] :as _request}]
+  (-> (services/incoming-post ds {:where [:and
+                                          [:= :id (:post-id path-params)]
+                                          [:= :creator-id (:id user)]]})
+      (res/response)))
+
+(defn post
+  {:summary "Update redacted status of post with the given id"
+   :parameters {:path [:map [:post-id {:title "post-id"
+                                       :description "post id"} :int]]
+                :body [:map
+                       [:redacted :boolean]]}
+   :responses  {200 {:body [:map [:message :string]]}
+                401 {:body [:map [:message :string]]}
+                403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params user body] :as _request}]
+  (services/update-incoming-post! ds {:where [:and
+                                              [:= :id (:post-id path-params)]
+                                              [:= :creator-id (:id user)]]
+                                      :data {:redacted (if (:redacted body) 1 0)}})
+  (res/response {:message "successfully updated post"}))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -53,6 +53,7 @@
             [source.routes.bundle-posts :as bundle-posts]
             [source.routes.bundle-post :as bundle-post]
             [source.routes.posts :as posts]
+            [source.routes.post :as post]
             [source.routes.admin-feeds :as admin-feeds]
             [source.routes.xml :as xml]
             [source.routes.data :as data]
@@ -192,7 +193,11 @@
       ["/:id"
        [""              (route {:get feed/get
                                 :post feed/post})]
-       ["/posts"        (route {:get posts/get})]
+       ["/posts"
+        [""             (route {:get posts/get})]
+        ["/:post-id"
+         [""            (route {:get post/get})]
+         ["/prune"      (route {:post post/post})]]]
        ["/categories"   (route {:get feed-categories/get
                                 :post feed-categories/post})]]]
 


### PR DESCRIPTION
Added endpoints to allow creators to prune or unprune incoming posts from their RSS feeds, as well as get a single incoming post by id.
