### PR TITLE
distributor filtering

### DIFF
--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -77,6 +77,24 @@
    (tables/foreign-key :bundle-id :bundles :id)
    (tables/foreign-key :content-type-id :content-types :id)))
 
+(def filtered-feeds
+  (tables/create-table-sql
+    :filtered-feeds
+    (tables/table-id)
+    [:feed-id :integer :not nil]
+    [:bundle-id :integer :not nil]
+    (tables/foreign-key :feed-id :feeds :id)
+    (tables/foreign-key :bundle-id :bundles :id)))
+
+(def filtered-posts
+  (tables/create-table-sql
+    :filtered-posts
+    (tables/table-id)
+    [:post-id :integer :not nil]
+    [:bundle-id :integer :not nil]
+    (tables/foreign-key :post-id :incoming-posts :id)
+    (tables/foreign-key :bundle-id :bundles :id)))
+
 (def feeds
   (tables/create-table-sql
    :feeds

--- a/src/source/migrations/005_filtered_feeds_posts.clj
+++ b/src/source/migrations/005_filtered_feeds_posts.clj
@@ -1,0 +1,18 @@
+(ns source.migrations.005-filtered-feeds-posts
+  (:require [source.db.master]
+            [source.db.tables :as tables]))
+
+(defn run-up! [context]
+  (let [ds-master (:db-master context)]
+    (tables/create-tables!
+     ds-master
+     :source.db.master
+     [:filtered-feeds
+      :filtered-posts])))
+
+(defn run-down! [context]
+  (let [ds-master (:db-master context)]
+    (tables/drop-tables! 
+      ds-master
+      [:filtered-feeds
+       :filtered-posts])))

--- a/src/source/routes/bundle_feeds.clj
+++ b/src/source/routes/bundle_feeds.clj
@@ -9,7 +9,9 @@
   {:summary "get all feeds present in the bundle authorised by uuid"
    :parameters {:query [:map
                         [:uuid :string]
-                        [:type {:optional true} :int]]
+                        [:type {:optional true} :int]
+                        [:latest {:optional true} :boolean]
+                        [:nonfiltered {:optional true} :boolean]]
                 :body [:map [:category-ids [:vector :int]]]}
    :responses {200 {:body [:vector
                            [:map
@@ -32,7 +34,7 @@
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [bundle-ds (db.util/conn :bundle bundle-id)
         {:keys [category-ids]} body
-        {:keys [type latest]} (walk/keywordize-keys query-params)
+        {:keys [type latest nonfiltered]} (walk/keywordize-keys query-params)
         feed-ids (mapv :feed-id (services/outgoing-posts bundle-ds))
         category-filtered-feed-ids (if (empty? category-ids)
                                      feed-ids
@@ -41,8 +43,12 @@
                                            [:in :category-id category-ids])
                                           (services/feed-categories ds)
                                           (mapv :feed-id)))
+        blocked-feed-ids (if (some? nonfiltered)
+                           []
+                           (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]})))
         query (-> (when type [:= :content-type-id type])
-                  (hsql/where [:in :id category-filtered-feed-ids])
+                  (hsql/where [:in :id category-filtered-feed-ids]
+                              [:not [:in :id blocked-feed-ids]])
                   (hsql/order-by (when latest [:created-at :desc])))
         type-filtered (services/feeds ds query)]
 

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -3,7 +3,8 @@
             [source.db.util :as db.util]
             [clojure.walk :as walk]
             [ring.util.response :as res]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [honey.sql.helpers :as hsql]))
 
 (defn post
   {:summary "get all outgoing posts in the uuid-authorized bundle"
@@ -41,8 +42,13 @@
         start (when start (try (Integer/parseInt start) (catch Exception _)))
         limit (when limit (try (Integer/parseInt limit) (catch Exception _)))
 
-        filtered-posts (services/outgoing-posts bundle-ds {:where content-type-comp
-                                                           :order-by (when (= latest "true") [[:posted-at :desc]])})
+        blocked-feed-ids (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]}))
+        blocked-post-ids (mapv :post-id (services/filtered-posts ds {:where [:= :bundle-id bundle-id]}))
+
+        filtered-posts (services/outgoing-posts bundle-ds (-> (hsql/where content-type-comp
+                                                                          [:not [:in :id blocked-post-ids]]
+                                                                          [:not [:in :feed-id blocked-feed-ids]])
+                                                              (hsql/order-by (when (= latest "true") [[:posted-at :desc]]))))
 
         categorised-posts (vec (if (seq category-ids)
                                  (->> filtered-posts

--- a/src/source/routes/integration_filter_feed.clj
+++ b/src/source/routes/integration_filter_feed.clj
@@ -1,0 +1,50 @@
+(ns source.routes.integration-filter-feed
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "Returns true if the feed with the given id is filtered out by the integration with the given id"
+   :parameters {:path [:map
+                       [:id {:title "id"
+                             :description "integration id"} :int]
+                       [:feed-id {:title "feed-id"
+                                  :description "feed id"} :int]]}
+   :responses {200 {:body [:map [:filtered :boolean]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+
+  (let [returned (services/filtered-feeds ds {:where [:and
+                                                      [:= :bundle-id (:id path-params)]
+                                                      [:= :feed-id (:feed-id path-params)]]})
+        blocked (if (seq returned) true false)]
+    (res/response {:filtered blocked})))
+
+(defn post
+  {:summary "filters out the feed with the given id from the bundle with the given bundle id"
+   :parameters {:path [:map
+                       [:id {:title "id"
+                             :description "bundle id"} :int]
+                       [:feed-id {:title "feed-id"
+                                  :description "feed id"} :int]]
+                :body [:map
+                       [:filtered :boolean]]}
+   :responses {:body {200 [:map [:message :string]]
+                      401 [:map [:message :string]]
+                      403 [:map [:message :string]]}}}
+
+  [{:keys [ds path-params body] :as _request}]
+
+  (let [{:keys [filtered]} body
+        {:keys [id feed-id]} path-params]
+
+    (if filtered
+      (services/insert-filtered-feeds! ds {:data {:feed-id feed-id
+                                                  :bundle-id id}})
+
+      (services/delete-filtered-feed! ds {:where [:and
+                                                  [:= :feed-id feed-id]
+                                                  [:= :bundle-id id]]}))
+
+    (res/response {:message "Successfully updated feed filtering."})))

--- a/src/source/routes/integration_filter_feeds.clj
+++ b/src/source/routes/integration_filter_feeds.clj
@@ -1,0 +1,18 @@
+(ns source.routes.integration-filter-feeds
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "gets all filtered feed ids by integration id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:feed-id :int]
+                            [:bundle-id :int]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+
+  (res/response (services/filtered-feeds ds {:where [:= :bundle-id (:id path-params)]})))

--- a/src/source/routes/integration_filter_post.clj
+++ b/src/source/routes/integration_filter_post.clj
@@ -1,0 +1,47 @@
+(ns source.routes.integration-filter-post
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "Returns true if the post with the given id is filtered out by the integration with the given id"
+   :parameters {:path [:map
+                       [:id {:title "id"
+                             :description "integration id"} :int]
+                       [:post-id {:title "post-id"
+                                  :description "post id"} :int]]}
+   :responses {200 {:body [:map [:filtered :boolean]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+
+  (let [returned (services/filtered-feeds ds {:where [:and
+                                                      [:= :bundle-id (:id path-params)]
+                                                      [:= :post-id (:post-id path-params)]]})
+        blocked (if (seq returned) true false)]
+    (res/response {:filtered blocked})))
+
+(defn post
+  {:summary "filters out the post with the given id from the bundle with the given bundle id"
+   :parameters {:path [:map
+                       [:id {:title "id"
+                             :description "bundle id"} :int]
+                       [:post-id {:title "post-id"
+                                  :description "post id"} :int]]
+                :body [:map
+                       [:filtered :boolean]]}
+   :responses {:body {200 [:map [:message :string]]
+                      401 [:map [:message :string]]
+                      403 [:map [:message :string]]}}}
+
+  [{:keys [ds path-params body] :as _request}]
+
+  (let [{:keys [filtered]} body
+        {:keys [id post-id]} path-params]
+    (if filtered
+      (services/insert-filtered-posts! ds {:data {:post-id post-id
+                                                  :bundle-id id}})
+      (services/delete-filtered-post! ds {:where [:and
+                                                  [:= :post-id post-id]
+                                                  [:= :bundle-id id]]}))
+    (res/response {:message "successfully updated post filtering"})))

--- a/src/source/routes/integration_filter_posts.clj
+++ b/src/source/routes/integration_filter_posts.clj
@@ -1,0 +1,18 @@
+(ns source.routes.integration-filter-posts
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn get
+  {:summary "gets all filtered post ids by integration id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:post-id :int]
+                            [:bundle-id :int]]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params] :as _request}]
+
+  (res/response (services/filtered-posts ds {:where [:= :bundle-id (:id path-params)]})))

--- a/src/source/routes/post.clj
+++ b/src/source/routes/post.clj
@@ -27,20 +27,3 @@
                                           [:= :id (:post-id path-params)]
                                           [:= :creator-id (:id user)]]})
       (res/response)))
-
-(defn post
-  {:summary "Update redacted status of post with the given id"
-   :parameters {:path [:map [:post-id {:title "post-id"
-                                       :description "post id"} :int]]
-                :body [:map
-                       [:redacted :boolean]]}
-   :responses  {200 {:body [:map [:message :string]]}
-                401 {:body [:map [:message :string]]}
-                403 {:body [:map [:message :string]]}}}
-
-  [{:keys [ds path-params user body] :as _request}]
-  (services/update-incoming-post! ds {:where [:and
-                                              [:= :id (:post-id path-params)]
-                                              [:= :creator-id (:id user)]]
-                                      :data {:redacted (if (:redacted body) 1 0)}})
-  (res/response {:message "successfully updated post"}))

--- a/src/source/routes/post_prune.clj
+++ b/src/source/routes/post_prune.clj
@@ -1,0 +1,20 @@
+(ns source.routes.post-prune
+  (:require [source.services.interface :as services]
+            [ring.util.response :as res]))
+
+(defn post
+  {:summary "Update redacted status of post with the given id"
+   :parameters {:path [:map [:post-id {:title "post-id"
+                                       :description "post id"} :int]]
+                :body [:map
+                       [:redacted :boolean]]}
+   :responses  {200 {:body [:map [:message :string]]}
+                401 {:body [:map [:message :string]]}
+                403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds path-params user body] :as _request}]
+  (services/update-incoming-post! ds {:where [:and
+                                              [:= :id (:post-id path-params)]
+                                              [:= :creator-id (:id user)]]
+                                      :data {:redacted (if (:redacted body) 1 0)}})
+  (res/response {:message "successfully updated post"}))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -44,6 +44,10 @@
             [source.routes.integration :as integration]
             [source.routes.integration-key :as integration-key]
             [source.routes.integration-categories :as integration-categories]
+            [source.routes.integration-filter-feeds :as integration-filter-feeds]
+            [source.routes.integration-filter-feed :as integration-filter-feed]
+            [source.routes.integration-filter-posts :as integration-filter-posts]
+            [source.routes.integration-filter-post :as integration-filter-post]
             [source.routes.bundle :as bundle]
             [source.routes.bundle-categories :as bundle-categories]
             [source.routes.bundle-feeds :as bundle-feeds]
@@ -185,7 +189,16 @@
                                 :post integration/post})]
        ["/key"          (route {:post integration-key/post})]
        ["/categories"   (route {:get integration-categories/get
-                                :post integration-categories/post})]]]
+                                :post integration-categories/post})]
+       ["/filter"
+        ["/feeds"
+         [""            (route {:get integration-filter-feeds/get})]
+         ["/:feed-id"   (route {:get integration-filter-feed/get
+                                :post integration-filter-feed/post})]]
+        ["/posts"
+         [""            (route {:get integration-filter-posts/get})]
+         ["/:post-id"   (route {:get integration-filter-post/get
+                                :post integration-filter-post/post})]]]]]
 
      ["/feeds"          {:middleware [[mw/apply-auth]]
                          :tags #{"feeds"}}

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -54,6 +54,7 @@
             [source.routes.bundle-post :as bundle-post]
             [source.routes.posts :as posts]
             [source.routes.post :as post]
+            [source.routes.post-prune :as post-prune]
             [source.routes.admin-feeds :as admin-feeds]
             [source.routes.xml :as xml]
             [source.routes.data :as data]
@@ -197,7 +198,7 @@
         [""             (route {:get posts/get})]
         ["/:post-id"
          [""            (route {:get post/get})]
-         ["/prune"      (route {:post post/post})]]]
+         ["/prune"      (route {:post post-prune/post})]]]
        ["/categories"   (route {:get feed-categories/get
                                 :post feed-categories/post})]]]
 

--- a/src/source/services/filtered_feeds.clj
+++ b/src/source/services/filtered_feeds.clj
@@ -1,0 +1,35 @@
+(ns source.services.filtered-feeds
+  (:require [source.db.interface :as db]))
+
+(defn insert-filtered-feeds! [ds {:keys [data ret] :as opts}]
+  (->> {:tname :filtered-feeds
+        :data data
+        :ret ret}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-filtered-feeds! [ds {:keys [id data where] :as opts}]
+  (->> {:tname :filtered-feeds
+        :values data
+        :where (if (some? id) [:= :id id] where)
+        :ret :1}
+       (merge opts)
+       (db/update! ds)))
+
+(defn filtered-feeds
+  ([ds] (filtered-feeds ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :filtered-feeds
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn delete-filtered-feed! [ds {:keys [id where] :as opts}]
+  (->> {:tname :filtered-feeds
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))

--- a/src/source/services/filtered_posts.clj
+++ b/src/source/services/filtered_posts.clj
@@ -1,0 +1,35 @@
+(ns source.services.filtered-posts
+  (:require [source.db.interface :as db]))
+
+(defn insert-filtered-posts! [ds {:keys [data ret] :as opts}]
+  (->> {:tname :filtered-posts
+        :data data
+        :ret ret}
+       (merge opts)
+       (db/insert! ds)))
+
+(defn update-filtered-posts! [ds {:keys [id data where] :as opts}]
+  (->> {:tname :filtered-posts
+        :values data
+        :where (if (some? id) [:= :id id] where)
+        :ret :1}
+       (merge opts)
+       (db/update! ds)))
+
+(defn filtered-posts
+  ([ds] (filtered-posts ds {}))
+  ([ds {:keys [where] :as opts}]
+   (->> {:tname :filtered-posts
+         :where where
+         :ret :*}
+        (merge opts)
+        (db/find ds))))
+
+(defn delete-filtered-post! [ds {:keys [id where] :as opts}]
+  (->> {:tname :filtered-posts
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -18,7 +18,9 @@
              [source.services.feed-categories :as feed-categories]
              [source.services.jobs :as jobs]
              [source.services.businesses :as businesses]
-             [source.services.user-sectors :as user-sectors]))
+             [source.services.user-sectors :as user-sectors]
+             [source.services.filtered-feeds :as filtered-feeds]
+             [source.services.filtered-posts :as filtered-posts]))
 
 (defn users
   [& args]
@@ -311,6 +313,34 @@
 
 (defn job-metadata [ds {:keys [_id _where] :as opts}]
   (jobs/job-metadata ds opts))
+
+(defn insert-filtered-feeds! [ds {:keys [_data _ret] :as opts}]
+  (filtered-feeds/insert-filtered-feeds! ds opts))
+
+(defn update-filtered-feeds! [ds {:keys [_id _data _where] :as opts}]
+  (filtered-feeds/update-filtered-feeds! ds opts))
+
+(defn filtered-feeds
+  ([ds] (filtered-feeds ds {}))
+  ([ds {:keys [_where] :as opts}]
+   (filtered-feeds/filtered-feeds ds opts)))
+
+(defn delete-filtered-feed! [ds {:keys [_id _where] :as opts}]
+  (filtered-feeds/delete-filtered-feed! ds opts))
+
+(defn insert-filtered-posts! [ds {:keys [_data _ret] :as opts}]
+  (filtered-posts/insert-filtered-posts! ds opts))
+
+(defn update-filtered-posts! [ds {:keys [_id _data _where] :as opts}]
+  (filtered-posts/update-filtered-posts! ds opts))
+
+(defn filtered-posts
+  ([ds] (filtered-posts ds {}))
+  ([ds {:keys [_where] :as opts}]
+   (filtered-posts/filtered-posts ds opts)))
+
+(defn delete-filtered-post! [ds {:keys [_id _where] :as opts}]
+  (filtered-posts/delete-filtered-post! ds opts))
 
 (comment
   (users (db/ds :master))


### PR DESCRIPTION
Added 2 tables, filtered feeds and filtered posts, allowing us to keep track of which feeds and posts are filtered out by which integrations. Migrations have been added for these tables. There are endpoints to filter out feeds or posts, as well as get all/one filtered feed(s)/post(s). The data in these tables is then used currently in the bundle feeds and posts routes to ensure filtered content does not get returned. In future a list of creator channels / content partners will be based on all historical channels with the help of analytics, and filtered out content will never make it into the bundle.
