### PR TITLE
db connection issues

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,9 +14,9 @@
         ring/ring-json {:mvn/version "0.5.1"}
         ring/ring-defaults {:mvn/version "0.6.0"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
-        io.github.modulr-software/congest {:mvn/version "0.1.6"}
-        com.github.seancorfield/next.jdbc {:mvn/version "1.3.994"}
-        org.xerial/sqlite-jdbc {:mvn/version "3.49.1.0"}
+        io.github.modulr-software/congest {:mvn/version "0.1.7"}
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.1070"}
+        org.xerial/sqlite-jdbc {:mvn/version "3.51.0.0"}
         buddy/buddy-core {:mvn/version "1.12.0-430"}
         buddy/buddy-sign {:mvn/version "3.5.351"}
         aero/aero {:mvn/version "1.1.6"}

--- a/src/source/db/util.clj
+++ b/src/source/db/util.clj
@@ -6,10 +6,10 @@
 (defn db-path [dbname]
   (let [db-dir (conf/read-value :database :dir)]
     (str
-      db-dir
-      (when (not (= (last db-dir) \/))
-        "/")
-      dbname)))
+     db-dir
+     (when (not (= (last db-dir) \/))
+       "/")
+     dbname)))
 
 (defn db-name
   ([type]
@@ -18,10 +18,13 @@
    (str (name type) "_" id)))
 
 (defn- -conn [dbname]
-  (-> {:dbtype (conf/read-value :database :type)}
-       (merge {:dbname (db-path dbname)})
-       (jdbc/get-connection)
-       (jdbc/with-options {:builder-fn rs/as-unqualified-lower-maps})))
+  (let [conn (-> {:dbtype (conf/read-value :database :type)}
+                 (merge {:dbname (db-path dbname)})
+                 (jdbc/get-connection))]
+    (jdbc/execute! conn ["PRAGMA journal_mode = WAL;"])
+    (jdbc/execute! conn ["PRAGMA synchronous = NORMAL;"])
+    (jdbc/with-options conn {:builder-fn rs/as-unqualified-lower-maps})
+    conn))
 
 (defn conn
   ([]
@@ -32,4 +35,3 @@
   ([db-type id]
    (assert (or (= db-type :bundle) (= db-type :creator)))
    (-conn (db-name db-type id))))
-

--- a/src/source/routes/bundle_categories.clj
+++ b/src/source/routes/bundle_categories.clj
@@ -14,9 +14,9 @@
                404 {:body [:map [:message :string]]}}}
 
   [{:keys [bundle-id ds] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        feed-ids (->> (services/outgoing-posts bundle-ds)
-                      (mapv :feed-id))
-        category-ids (->> (services/feed-categories ds {:where [:in :feed-id feed-ids]})
-                          (mapv :category-id))]
-    (res/response (services/categories ds {:where [:in :id category-ids]}))))
+  (with-open [bundle-ds (db.util/conn :bundle bundle-id)]
+    (let [feed-ids (->> (services/outgoing-posts bundle-ds)
+                        (mapv :feed-id))
+          category-ids (->> (services/feed-categories ds {:where [:in :feed-id feed-ids]})
+                            (mapv :category-id))]
+      (res/response (services/categories ds {:where [:in :id category-ids]})))))

--- a/src/source/routes/bundle_feeds.clj
+++ b/src/source/routes/bundle_feeds.clj
@@ -32,24 +32,24 @@
                404 {:body [:map [:message :string]]}}}
 
   [{:keys [ds bundle-id query-params body] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        {:keys [category-ids]} body
-        {:keys [type latest nonfiltered]} (walk/keywordize-keys query-params)
-        feed-ids (mapv :feed-id (services/outgoing-posts bundle-ds))
-        category-filtered-feed-ids (if (empty? category-ids)
-                                     feed-ids
-                                     (->> (hsql/where
-                                           [:in :feed-id feed-ids]
-                                           [:in :category-id category-ids])
-                                          (services/feed-categories ds)
-                                          (mapv :feed-id)))
-        blocked-feed-ids (if (some? nonfiltered)
-                           []
-                           (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]})))
-        query (-> (when type [:= :content-type-id type])
-                  (hsql/where [:in :id category-filtered-feed-ids]
-                              [:not [:in :id blocked-feed-ids]])
-                  (hsql/order-by (when latest [:created-at :desc])))
-        type-filtered (services/feeds ds query)]
+  (with-open [bundle-ds (db.util/conn :bundle bundle-id)]
+    (let [{:keys [category-ids]} body
+          {:keys [type latest nonfiltered]} (walk/keywordize-keys query-params)
+          feed-ids (mapv :feed-id (services/outgoing-posts bundle-ds))
+          category-filtered-feed-ids (if (empty? category-ids)
+                                       feed-ids
+                                       (->> (hsql/where
+                                             [:in :feed-id feed-ids]
+                                             [:in :category-id category-ids])
+                                            (services/feed-categories ds)
+                                            (mapv :feed-id)))
+          blocked-feed-ids (if (some? nonfiltered)
+                             []
+                             (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]})))
+          query (-> (when type [:= :content-type-id type])
+                    (hsql/where [:in :id category-filtered-feed-ids]
+                                [:not [:in :id blocked-feed-ids]])
+                    (hsql/order-by (when latest [:created-at :desc])))
+          type-filtered (services/feeds ds query)]
 
-    (res/response type-filtered)))
+      (res/response type-filtered))))

--- a/src/source/routes/bundle_post.clj
+++ b/src/source/routes/bundle_post.clj
@@ -26,7 +26,7 @@
                404 {:body [:map [:message :string]]}}}
 
   [{:keys [bundle-id path-params] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        id (:id path-params)]
-    (res/response (services/outgoing-post bundle-ds {:id id}))))
+  (with-open [bundle-ds (db.util/conn :bundle bundle-id)]
+    (let [id (:id path-params)]
+      (res/response (services/outgoing-post bundle-ds {:id id})))))
 

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -34,43 +34,44 @@
                404 {:boy [:map [:message :string]]}}}
 
   [{:keys [ds bundle-id query-params body] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        {:keys [limit start type latest]} (walk/keywordize-keys query-params)
-        {:keys [category-ids]} body
+  (with-open [bundle-ds (db.util/conn :bundle bundle-id)]
+    (let [{:keys [limit start type latest]} (walk/keywordize-keys query-params)
+          {:keys [category-ids]} body
 
-        content-type-comp (when type [:= :content-type-id type])
-        start (when start (try (Integer/parseInt start) (catch Exception _)))
-        limit (when limit (try (Integer/parseInt limit) (catch Exception _)))
+          content-type-comp (when type [:= :content-type-id type])
+          start (when start (try (Integer/parseInt start) (catch Exception _)))
+          limit (when limit (try (Integer/parseInt limit) (catch Exception _)))
 
-        blocked-feed-ids (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]}))
-        blocked-post-ids (mapv :post-id (services/filtered-posts ds {:where [:= :bundle-id bundle-id]}))
+          blocked-feed-ids (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]}))
+          blocked-post-ids (mapv :post-id (services/filtered-posts ds {:where [:= :bundle-id bundle-id]}))
 
-        filtered-posts (services/outgoing-posts bundle-ds (-> (hsql/where content-type-comp
-                                                                          [:not [:in :id blocked-post-ids]]
-                                                                          [:not [:in :feed-id blocked-feed-ids]])
-                                                              (hsql/order-by (when (= latest "true") [[:posted-at :desc]]))))
+          filtered-posts (services/outgoing-posts bundle-ds (-> (hsql/where content-type-comp
+                                                                            [:not [:in :id blocked-post-ids]]
+                                                                            [:not [:in :feed-id blocked-feed-ids]])
+                                                                (hsql/order-by (when (= latest "true") [[:posted-at :desc]]))))
 
-        categorised-posts (vec (if (seq category-ids)
-                                 (->> filtered-posts
-                                      (mapv
-                                       (fn [post]
-                                         (when (seq (set/intersection
-                                                     (set category-ids)
-                                                     (->> {:feed-id (:feed-id post)}
-                                                          (services/categories-by-feed ds)
-                                                          (mapv :id)
-                                                          (set))))
-                                           post)))
-                                      (remove nil?))
-                                 filtered-posts))
+          categorised-posts (vec
+                             (if (seq category-ids)
+                               (->> filtered-posts
+                                    (mapv
+                                     (fn [post]
+                                       (when (seq (set/intersection
+                                                   (set category-ids)
+                                                   (->> {:feed-id (:feed-id post)}
+                                                        (services/categories-by-feed ds)
+                                                        (mapv :id)
+                                                        (set))))
+                                         post)))
+                                    (remove nil?))
+                               filtered-posts))
 
-        valid-start? (and (some? start) (>= start 0) (< start (count categorised-posts)))
-        started-posts (if valid-start?
-                        (subvec categorised-posts start)
-                        categorised-posts)
+          valid-start? (and (some? start) (>= start 0) (< start (count categorised-posts)))
+          started-posts (if valid-start?
+                          (subvec categorised-posts start)
+                          categorised-posts)
 
-        limited-posts (if (and (some? limit) (> (count started-posts) limit))
-                        (subvec started-posts 0 limit)
-                        started-posts)]
+          limited-posts (if (and (some? limit) (> (count started-posts) limit))
+                          (subvec started-posts 0 limit)
+                          started-posts)]
 
-    (res/response limited-posts)))
+      (res/response limited-posts))))

--- a/src/source/routes/integration_categories.clj
+++ b/src/source/routes/integration_categories.clj
@@ -13,11 +13,11 @@
                             [:name :string]]]}}}
 
   [{:keys [ds path-params] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle (:id path-params))
-        category-ids (services/category-id-by-bundle bundle-ds {:bundle-id (:id path-params)})
-        id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)
-        categories (services/categories ds {:where [:in :id id-vec]})]
-    (res/response categories)))
+  (with-open [bundle-ds (db.util/conn :bundle (:id path-params))]
+    (let [category-ids (services/category-id-by-bundle bundle-ds {:bundle-id (:id path-params)})
+          id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)
+          categories (services/categories ds {:where [:in :id id-vec]})]
+      (res/response categories))))
 
 (defn post
   {:summary "update categories belonging to the integration with the given id"
@@ -30,10 +30,10 @@
    :responses {200 {:body [:map [:message :string]]}}}
 
   [{:keys [path-params body] :as _request}]
-  (let [update-data (reduce (fn [acc {:keys [id]}]
-                              (conj acc {:bundle-id (:id path-params)
-                                         :category-id id})) [] body)
-        bundle-ds (db.util/conn :bundle (:id path-params))]
-    (services/delete-bundle-category! bundle-ds {:where [:= :bundle-id (:id path-params)]})
-    (services/insert-bundle-category! bundle-ds {:data update-data})
-    (res/response {:message "successfully updated integration categories"})))
+  (with-open [bundle-ds (db.util/conn :bundle (:id path-params))]
+    (let [update-data (reduce (fn [acc {:keys [id]}]
+                                (conj acc {:bundle-id (:id path-params)
+                                           :category-id id})) [] body)]
+      (services/delete-bundle-category! bundle-ds {:where [:= :bundle-id (:id path-params)]})
+      (services/insert-bundle-category! bundle-ds {:data update-data})
+      (res/response {:message "successfully updated integration categories"}))))

--- a/src/source/routes/jobs_view.clj
+++ b/src/source/routes/jobs_view.clj
@@ -1,0 +1,23 @@
+(ns source.routes.jobs-view
+  (:require [ring.util.response :as res]
+            [congest.jobs :as congest]
+            [clojure.walk :as walk]))
+
+(defn stringify-unknowns [x]
+  (walk/postwalk
+   (fn [v]
+     (if (or (map? v)
+             (sequential? v)
+             (string? v)
+             (number? v)
+             (boolean? v)
+             (keyword? v)
+             (nil? v))
+       v
+       (str v))) x))
+
+(defn get [{:keys [js]}]
+ ;(let [raw-jobs (congest/view js)
+ ;      formatted (stringify-unknowns raw-jobs)]
+ ;  (res/response formatted))
+  (res/response {:message "Hello, world!"}))

--- a/src/source/routes/jobs_view.clj
+++ b/src/source/routes/jobs_view.clj
@@ -17,7 +17,6 @@
        (str v))) x))
 
 (defn get [{:keys [js]}]
- ;(let [raw-jobs (congest/view js)
- ;      formatted (stringify-unknowns raw-jobs)]
- ;  (res/response formatted))
-  (res/response {:message "Hello, world!"}))
+  (let [raw-jobs (congest/view js)
+        formatted (stringify-unknowns raw-jobs)]
+    (res/response formatted)))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -63,6 +63,7 @@
             [source.routes.xml :as xml]
             [source.routes.data :as data]
             [source.routes.jobs :as jobs]
+            [source.routes.jobs-view :as jobs-view]
             [source.routes.job :as job]
             [source.routes.job-deregister :as job-deregister]
             [source.routes.job-start :as job-start]
@@ -265,6 +266,7 @@
       ["/jobs"
        [""                      {:get jobs/get}]
        ["/manage"
+        ["/view"                {:get jobs-view/get}]
         ["/register"            {:post jobs/post}]]
        ["/:id"
         [""                     {:get job/get}]


### PR DESCRIPTION
This PR addresses a memory leak and db write locks that result from the way database connections are managed. The database write locks occur because of asynchronous writes issued by jobs on server startup - this has been mitigated by including the Write-Ahead Logging option in SQLite to allow for better concurrency.

During testing to identify the write-locking issue, I made an admin endpoint to view all the raw job data inside of congest - though this currently does not have schemas or documentation.

In addition, a memory leak was caused in bundle endpoints because database connections to the bundle databases were being opened but never closed. This has been addressed by using the with-open macro to automatically close the connection when it goes out of scope.