### PR TITLE
analytics endpoints

### DIFF
--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -28,7 +28,7 @@
        (res/status 401)))))
 
 (defn wrap-auth-user-type
-  "returns an unauthorized response if the user's type is not the required user type (provider | distributor | admin)"
+  "returns an unauthorized response if the user's type is not the required user type (creator | distributor | admin)"
   [handler & {:keys [required-type]}]
   (fn [request]
     (let [ds (db.util/conn :master)
@@ -38,7 +38,7 @@
                              (:type))]
       (cond
         (not (some? required-type)) (handler request)
-        (and (= user-type (name :admin)) (= user-type expected-type)) (handler request)
+        (and (= user-type (name required-type)) (= user-type expected-type)) (handler request)
         :else (->
                (res/response {:message "Unauthorized"})
                (res/status 403))))))

--- a/src/source/routes/analytics/bundle/posts/_id_/views.clj
+++ b/src/source/routes/analytics/bundle/posts/_id_/views.clj
@@ -1,0 +1,16 @@
+(ns source.routes.analytics.bundle.posts.-id-.views
+  (:require [ring.util.response :as res]
+            [source.services.analytics.interface :as analytics]
+            [source.services.interface :as services]))
+
+(defn post
+  {:summary "Explicitly insert a view event for the post with the given id for the purpose of analytics"
+   :parameters {:query [:map [:uuid :string]]
+                :path [:map [:id {:title "id"
+                                  :description "post id"} :int]]}
+   :responses {200 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds bundle-id path-params] :as _request}]
+  (let [post (services/incoming-post ds {:id (:id path-params)})]
+    (analytics/insert-post-view! ds post bundle-id)
+    (res/response {:message "Successfully inserted view event"})))

--- a/src/source/routes/analytics/creator/deltas.clj
+++ b/src/source/routes/analytics/creator/deltas.clj
@@ -1,22 +1,22 @@
-(ns source.routes.analytics.creator.general
-  (:require [source.services.analytics.interface :as analytics]
+(ns source.routes.analytics.creator.deltas
+  (:require [clojure.walk :as w]
             [ring.util.response :as res]
-            [clojure.walk :as w]))
+            [source.services.analytics.interface :as analytics]))
 
 (defn get
-  {:summary "Gets the number of impressions, clicks and views per day for a creator over the given time period. Optionally filtered by feed."
+  {:summary "Returns the percentage of growth in impressions, clicks and views per week, over the given time period. Optionally filtered by feed."
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]
                         [:feed {:optional true} [:maybe :int]]]}
    :responses {200 {:body [:vector
                            [:map
-                            [:day :string]
+                            [:week :string]
                             [:impressions :int]
                             [:clicks :int]
                             [:views :int]]]}}}
 
   [{:keys [ds user query-params] :as _request}]
   (let [{:keys [mindate maxdate feed]} (w/keywordize-keys query-params)]
-    (res/response (analytics/interval-statistics-query ds :daily mindate maxdate {:creator-id (:id user)
-                                                                                  :feed-id feed}))))
+    (res/response (analytics/weekly-growth-averages ds mindate maxdate {:creator-id (:id user)
+                                                                        :feed-id feed}))))

--- a/src/source/routes/analytics/creator/top.clj
+++ b/src/source/routes/analytics/creator/top.clj
@@ -21,8 +21,8 @@
 
   [{:keys [ds user query-params] :as _request}]
   (let [{:keys [n mindate maxdate top contenttype]} (w/keywordize-keys query-params)
-        top-field (if (= top "post") :post-id :bundle-id)]
-    (res/response (set/rename-keys
-                   (analytics/top-statistics-query ds mindate maxdate n top-field {:creator-id (:id user)
-                                                                                   :content-type-id contenttype})
-                   {top-field :top}))))
+        top-field (if (= top "post") :post-id :bundle-id)
+        results (analytics/top-statistics-query ds mindate maxdate n top-field {:creator-id (:id user)
+                                                                                :content-type-id contenttype})]
+    (res/response (mapv (fn [result]
+                          (set/rename-keys result {top-field :top})) results))))

--- a/src/source/routes/analytics/creator/top.clj
+++ b/src/source/routes/analytics/creator/top.clj
@@ -1,0 +1,28 @@
+(ns source.routes.analytics.creator.top
+  (:require [source.services.analytics.interface :as analytics]
+            [ring.util.response :as res]
+            [clojure.walk :as w]
+            [clojure.set :as set]))
+
+(defn get
+  {:summary "Get the top n records with the highest number of impressions, clicks and views, in terms of the given top field. Optionally filtered by content type."
+   :parameters {:query [:map
+                        [:n :int]
+                        [:mindate :string]
+                        [:maxdate :string]
+                        [:top [:enum "post" "bundle"]]
+                        [:contenttype {:optional true} [:maybe :int]]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:top :string]
+                            [:impressions :int]
+                            [:clicks :int]
+                            [:views :int]]]}}}
+
+  [{:keys [ds user query-params] :as _request}]
+  (let [{:keys [n mindate maxdate top contenttype]} (w/keywordize-keys query-params)
+        top-field (if (= top "post") :post-id :bundle-id)]
+    (res/response (set/rename-keys
+                   (analytics/top-statistics-query ds mindate maxdate n top-field {:creator-id (:id user)
+                                                                                   :content-type-id contenttype})
+                   {top-field :top}))))

--- a/src/source/routes/analytics/distributor/general.clj
+++ b/src/source/routes/analytics/distributor/general.clj
@@ -1,14 +1,14 @@
-(ns source.routes.analytics.creator.general
+(ns source.routes.analytics.distributor.general
   (:require [source.services.analytics.interface :as analytics]
             [ring.util.response :as res]
             [clojure.walk :as w]))
 
 (defn get
-  {:summary "Gets the number of impressions, clicks and views per day for a creator over the given time period. Optionally filtered by feed."
+  {:summary "Gets the number of impressions, clicks and views per day for a distributor over the given time period. Optionally filtered by bundle."
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]
-                        [:feed {:optional true} [:maybe :int]]]}
+                        [:bundle {:optional true} [:maybe :int]]]}
    :responses {200 {:body [:vector
                            [:map
                             [:day :string]
@@ -17,6 +17,6 @@
                             [:views :int]]]}}}
 
   [{:keys [ds user query-params] :as _request}]
-  (let [{:keys [mindate maxdate feed]} (w/keywordize-keys query-params)]
-    (res/response (analytics/interval-statistics-query ds :daily mindate maxdate {:creator-id (:id user)
-                                                                                  :feed-id feed}))))
+  (let [{:keys [mindate maxdate bundle]} (w/keywordize-keys query-params)]
+    (res/response (analytics/interval-statistics-query ds :daily mindate maxdate {:distributor-id (:id user)
+                                                                                  :bundle-id bundle}))))

--- a/src/source/routes/analytics/distributor/top.clj
+++ b/src/source/routes/analytics/distributor/top.clj
@@ -1,0 +1,28 @@
+(ns source.routes.analytics.distributor.top
+  (:require [source.services.analytics.interface :as analytics]
+            [ring.util.response :as res]
+            [clojure.walk :as w]
+            [clojure.set :as set]))
+
+(defn get
+  {:summary "Get the top n records with the highest number of impressions, clicks and views, in terms of the given top field. Optionally filtered by content type."
+   :parameters {:query [:map
+                        [:n :int]
+                        [:mindate :string]
+                        [:maxdate :string]
+                        [:top [:enum "post" "feed"]]
+                        [:contenttype {:optional true} [:maybe :int]]]}
+   :responses {200 {:body [:vector
+                           [:map
+                            [:top :string]
+                            [:impressions :int]
+                            [:clicks :int]
+                            [:views :int]]]}}}
+
+  [{:keys [ds user query-params] :as _request}]
+  (let [{:keys [n mindate maxdate top contenttype]} (w/keywordize-keys query-params)
+        top-field (if (= top "post") :post-id :feed-id)]
+    (res/response (set/rename-keys
+                   (analytics/top-statistics-query ds mindate maxdate n top-field {:distributor-id (:id user)
+                                                                                   :content-type-id contenttype})
+                   {top-field :top}))))

--- a/src/source/routes/analytics/distributor/top.clj
+++ b/src/source/routes/analytics/distributor/top.clj
@@ -21,8 +21,8 @@
 
   [{:keys [ds user query-params] :as _request}]
   (let [{:keys [n mindate maxdate top contenttype]} (w/keywordize-keys query-params)
-        top-field (if (= top "post") :post-id :feed-id)]
-    (res/response (set/rename-keys
-                   (analytics/top-statistics-query ds mindate maxdate n top-field {:distributor-id (:id user)
-                                                                                   :content-type-id contenttype})
-                   {top-field :top}))))
+        top-field (if (= top "post") :post-id :feed-id)
+        results (analytics/top-statistics-query ds mindate maxdate n top-field {:distributor-id (:id user)
+                                                                                :content-type-id contenttype})]
+    (res/response (mapv (fn [result]
+                          (set/rename-keys result {top-field :top})) results))))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -41,6 +41,11 @@
             [source.routes.feed :as feed]
             [source.routes.feed-categories :as feed-categories]
             [source.routes.analytics.creator.general :as analytics-creator-general]
+            [source.routes.analytics.creator.deltas :as analytics-creator-deltas]
+            [source.routes.analytics.creator.top :as analytics-creator-top]
+            [source.routes.analytics.distributor.general :as analytics-distributor-general]
+            [source.routes.analytics.distributor.top :as analytics-distributor-top]
+            [source.routes.analytics.bundle.posts.-id-.views :as analytics-bundle-posts-id-views]
             [source.routes.integrations :as integrations]
             [source.routes.integration :as integration]
             [source.routes.integration-key :as integration-key]
@@ -218,12 +223,18 @@
                                 :post feed-categories/post})]]]
 
      ["/analytics"
-      ["/creator"
+      ["/creator"       {:middleware [[mw/apply-auth {:required-type :creator}]]}
        ["/general"      (route {:get analytics-creator-general/get})]
-       ["/deltas"]
-       ["/top"]]
-      ["/bundle"]
-      ["admin"]]
+       ["/deltas"       (route {:get analytics-creator-deltas/get})]
+       ["/top"          (route {:get analytics-creator-top/get})]]
+      ["/distributor"   {:middleware [[mw/apply-auth {:required-type :distributor}]]}
+       ["/general"      (route {:get analytics-distributor-general/get})]
+       ["/top"          (route {:get analytics-distributor-top/get})]]
+      ["/bundle"        {:middleware [[mw/apply-bundle]]}
+       ["/posts"
+        ["/:id"
+         ["/views"       (route {:post analytics-bundle-posts-id-views/post})]]]]
+      ["admin"          {:middleware [[mw/apply-auth {:required-type :admin}]]}]]
 
      ["/bundle"        {:middleware [[mw/apply-bundle]]
                         :tags #{"bundles"}}

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -233,8 +233,10 @@
       ["/bundle"        {:middleware [[mw/apply-bundle]]}
        ["/posts"
         ["/:id"
-         ["/views"       (route {:post analytics-bundle-posts-id-views/post})]]]]
-      ["admin"          {:middleware [[mw/apply-auth {:required-type :admin}]]}]]
+         ["/views"      (route {:post analytics-bundle-posts-id-views/post})]]]]
+      ["admin"          {:middleware [[mw/apply-auth {:required-type :admin}]]}
+       ["/general"]
+       ["/top"]]]
 
      ["/bundle"        {:middleware [[mw/apply-bundle]]
                         :tags #{"bundles"}}

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -7,7 +7,7 @@
 
 (defn metric-query
   "Generic select query function for returning analytics data from the events table"
-  [ds {:keys [select order-by group-by metric feed-id post-id content-type-id bundle-id creator-id distributor-id min-date max-date category-ids ret]}]
+  [ds {:keys [select order-by group-by limit metric feed-id post-id content-type-id bundle-id creator-id distributor-id min-date max-date category-ids where ret]}]
   (let [clauses (cond-> {}
                   (some? metric) (hsql/where [:= :event metric])
                   (some? feed-id) (hsql/where [:= :feed-id feed-id])
@@ -16,28 +16,31 @@
                   (some? bundle-id) (hsql/where [:= :bundle-id bundle-id])
                   (some? creator-id) (hsql/where [:= :creator-id creator-id])
                   (some? distributor-id) (hsql/where [:= :distributor-id distributor-id])
+                  (some? where) (merge where)
                   (and (some? min-date) (nil? max-date)) (hsql/where [:>= :timestamp min-date])
                   (and (some? max-date) (nil? min-date)) (hsql/where [:<= :timestamp max-date])
                   (and (some? min-date) (some? max-date)) (hsql/where [:between :timestamp min-date max-date])
                   (some? select) (merge select)
+                  (nil? select) (merge {:select [[[:count :*] :total]]})
+                  (some? limit) (hsql/limit limit)
                   (some? order-by) (merge order-by)
                   (some? group-by) (merge group-by)
                   (seq category-ids) (-> (hsql/join [:event-categories :ec] [:= :events.id :ec.event-id])
                                          (hsql/where [:in :ec.category-id category-ids])))]
     (hon/execute!
      ds
-     (merge {:select [[[:count :*] :total]]
-             :from [:events]}
+     (merge {:from [:events]}
             clauses)
      {:ret (if ret ret :*)})))
 
 (defn statistics-query
-  "returns the number of impressions, clicks and views, filtered by any other arguments accepted by metric-query"
-  [ds opts]
+  "Returns the number of impressions, clicks and views, filtered by any other arguments accepted by metric-query.
+  If ret is not given, returns a single record."
+  [ds {:keys [ret] :as opts}]
   (metric-query ds (merge {:select (hsql/select [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]
                                                 [(hsql/filter :%count.* (hsql/where := :event "click")) :clicks]
                                                 [(hsql/filter :%count.* (hsql/where := :event "view")) :views])
-                           :ret :1}
+                           :ret (if ret ret :1)}
                           opts)))
 
 (defn interval-statistics-query
@@ -69,9 +72,25 @@
                              :order-by (hsql/order-by column)}
                             opts))))
 
+(defn top-statistics-query
+  "Returns the top n of the given top field in order of the number of their impressions, clicks and views within the given time period"
+  [ds min-date max-date n top-field opts]
+  (metric-query ds (merge {:select (hsql/select top-field
+                                                [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]
+                                                [(hsql/filter :%count.* (hsql/where := :event "click")) :clicks]
+                                                [(hsql/filter :%count.* (hsql/where := :event "view")) :views])
+                           :min-date min-date
+                           :max-date max-date
+                           :where (hsql/where [:!= top-field nil])
+                           :group-by (hsql/group-by top-field)
+                           :order-by (hsql/order-by [:impressions :desc] [:clicks :desc] [:views :desc])
+                           :limit n
+                           :ret :*}
+                          opts)))
+
 (defn weekly-growth-averages
   "Returns the percentage of growth in impressions, clicks and views per week, over the given time period. 
-  Uses the first week as a basis for comparison, not included in results.
+  Uses the first week as a basis for comparison.
   Can be filtered by any other arguments accepted by metric-query."
   [ds min-date max-date opts]
   (let [weeks (interval-statistics-query ds :weekly min-date max-date opts)
@@ -171,7 +190,7 @@
                         :bundle-id bundle-id
                         :distributor-id (:user-id bundle)}) feeds)
         events' (insert-event! ds {:data events
-                                  :ret :*})]
+                                   :ret :*})]
     (insert-feed-event-categories! ds events' feeds)))
 
 (defn insert-post-impressions!
@@ -189,7 +208,7 @@
                         :bundle-id bundle-id
                         :distributor-id (:user-id bundle)}) posts)
         events' (insert-event! ds {:data events
-                                  :ret :*})]
+                                   :ret :*})]
     (insert-post-event-categories! ds events' posts)))
 
 (defn insert-feed-click!
@@ -205,7 +224,7 @@
                :bundle-id bundle-id
                :distributor-id (:user-id bundle)}
         event' (insert-event! ds {:data event
-                                 :ret :*})]
+                                  :ret :*})]
     (insert-feed-event-categories! ds event' feed)))
 
 (defn insert-post-click!
@@ -222,7 +241,7 @@
                :bundle-id bundle-id
                :distributor-id (:user-id bundle)}
         event' (insert-event! ds {:data event
-                                 :ret :*})]
+                                  :ret :*})]
     (insert-post-event-categories! ds event' post)))
 
 (defn insert-post-view!
@@ -239,7 +258,7 @@
                :bundle-id bundle-id
                :distributor-id (:user-id bundle)}
         event' (insert-event! ds {:data event
-                                 :ret :*})]
+                                  :ret :*})]
     (insert-post-event-categories! ds event' post)))
 
 (comment
@@ -290,10 +309,7 @@
   (time (metric-query ds {:min-date "2025-11-25 15:00:00"
                           :feed-id "1"}))
 
-  (time (statistics-query ds {:content-type 1
-                              :creator-id 1
-                              :bundle-id 1
-                              :ret :1}))
+  (time (statistics-query ds {:ret :*}))
 
   (time (hon/find ds {:tname :events
                       :where [:< :id 500]
@@ -304,14 +320,14 @@
                          :data {:timestamp (str "2025-11-22" " 13:00:00")}
                          :ret :*}))
 
-  (time (hon/execute! ds (- (hsql/select [[:date :timestamp] :day]
-                                         [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]
-                                         [(hsql/filter :%count.* (hsql/where := :event "click")) :clicks]
-                                         [(hsql/filter :%count.* (hsql/where := :event "view")) :views])
-                            (hsql/from :events)
-                            (hsql/where [:between :timestamp "2025-11-17 00:00:00" "2025-11-24 23:59:59"])
-                            (hsql/group-by :day)
-                            (hsql/order-by :day)) {:ret :*}))
+  (time (hon/execute! ds (-> (hsql/select [[:date :timestamp] :day]
+                                          [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]
+                                          [(hsql/filter :%count.* (hsql/where := :event "click")) :clicks]
+                                          [(hsql/filter :%count.* (hsql/where := :event "view")) :views])
+                             (hsql/from :events)
+                             (hsql/where [:between :timestamp "2025-11-17 00:00:00" "2025-11-24 23:59:59"])
+                             (hsql/group-by :day)
+                             (hsql/order-by :day)) {:ret :*}))
 
   (time (interval-statistics-query ds :daily "2025-11-17" "2025-11-24" {:feed-id 4}))
 
@@ -356,12 +372,14 @@
                                  [(hsql/filter :%count.* (hsql/where := :event "view")) :views])))
 
   (time (insert-event! ds {:data {:timestamp (util/get-utc-timestamp-string)
-                                 :event "impression"
-                                 :feed-id 1
-                                 :content-type-id 1
-                                 :creator-id 1
-                                 :bundle-id 1
-                                 :distributor-id 1}}))
+                                  :event "impression"
+                                  :feed-id 1
+                                  :content-type-id 1
+                                  :creator-id 1
+                                  :bundle-id 1
+                                  :distributor-id 1}}))
+
+  (time (top-statistics-query ds "2025-11-17" "2025-11-24" 10 :post-id {}))
 
   ())
 

--- a/src/source/services/analytics/interface.clj
+++ b/src/source/services/analytics/interface.clj
@@ -26,6 +26,11 @@
   [ds min-date max-date opts]
   (core/weekly-growth-averages ds min-date max-date opts))
 
+(defn top-statistics-query
+  "Returns the top n of the given top field in order of the number of their impressions, clicks and views within the given time period."
+  [ds min-date max-date n top-field opts]
+  (core/top-statistics-query ds min-date max-date n top-field opts))
+
 (defn average-engagement
   "Returns the average engagement (average clicks and views) over the given time period.
   Can be filtered by any other arguments accepted by metric-query."


### PR DESCRIPTION
Added analytics http endpoints for getting necessary analytics data as a creator or a distributor, and an endpoint for inserting a post view for a bundle. The creator and distributor side endpoints include general data queries, deltas and top queries. This PR does not include admin side endpoints.