### PR TITLE
fix weekly growth endpoint

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,8 +32,9 @@
         hickory/hickory {:mvn/version "0.7.1"}
         com.draines/postal {:mvn/version "2.0.5"}
         hiccup/hiccup {:mvn/version "2.0.0"}
+        clojure.java-time/clojure.java-time {:mvn/version "1.4.3"}
         metosin/jsonista {:mvn/version "0.3.13"}
-        metosin/reitit {:mvn/version "0.9.1"} 
+        metosin/reitit {:mvn/version "0.9.1"}
         metosin/reitit-middleware {:mvn/version "0.9.1"}
         metosin/reitit-swagger {:mvn/version "0.9.1"}
         metosin/reitit-swagger-ui {:mvn/version "0.9.1"}}}

--- a/src/source/routes/analytics/creator/deltas.clj
+++ b/src/source/routes/analytics/creator/deltas.clj
@@ -1,6 +1,7 @@
 (ns source.routes.analytics.creator.deltas
   (:require [clojure.walk :as w]
             [ring.util.response :as res]
+            [java-time.api :as jt]
             [source.services.analytics.interface :as analytics]))
 
 (defn get
@@ -14,15 +15,25 @@
                             [:week :string]
                             [:impressions :float]
                             [:clicks :float]
-                            [:views :float]]]}}}
+                            [:views :float]]]}
+               400 {:body [:map [:message :string]]}}}
 
   [{:keys [ds user query-params] :as _request}]
-  (let [{:keys [mindate maxdate feed]} (w/keywordize-keys query-params)]
-    (let [results (analytics/weekly-growth-averages ds mindate maxdate {:creator-id (:id user)
-                                                                        :feed-id feed})
-          indexed-results (mapv (fn [{:keys [impressions clicks views]} i]
-                                  {:week (str "week " i)
-                                   :impressions impressions
-                                   :clicks clicks
-                                   :views views}) results (range 1 (inc (count results))))]
-      (res/response indexed-results))))
+  (let [{:keys [mindate maxdate feed]} (w/keywordize-keys query-params)
+        {:keys [parsed-mindate parsed-maxdate]} (try
+                                                  {:parsed-mindate (jt/local-date mindate)
+                                                   :parsed-maxdate (jt/local-date maxdate)}
+                                                  (catch Exception _ (-> (res/response {:message "Invalid date format. Date must be in the format YYYY-MM-DD."})
+                                                                         (res/status 400))))
+        days-between (.until parsed-mindate parsed-maxdate java.time.temporal.ChronoUnit/DAYS)
+        results (analytics/weekly-growth-averages ds mindate maxdate {:creator-id (:id user)
+                                                                      :feed-id feed})
+        indexed-results (mapv (fn [{:keys [impressions clicks views]} i]
+                                {:week (str "week " i)
+                                 :impressions impressions
+                                 :clicks clicks
+                                 :views views}) results (range 1 (inc (count results))))]
+    (if (>= days-between 14)
+      (res/response indexed-results)
+      (-> (res/response {:message "Date range too small. Date range must include at least 2 weeks."})
+          (res/status 400)))))

--- a/src/source/routes/analytics/creator/deltas.clj
+++ b/src/source/routes/analytics/creator/deltas.clj
@@ -5,7 +5,8 @@
             [source.services.analytics.interface :as analytics]))
 
 (defn get
-  {:summary "Returns the percentage of growth in impressions, clicks and views per week, over the given time period. Optionally filtered by feed."
+  {:summary "Returns the percentage of growth in impressions, clicks and views per week, over the given time period. Optionally filtered by feed. 
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]
@@ -23,17 +24,12 @@
         {:keys [parsed-mindate parsed-maxdate]} (try
                                                   {:parsed-mindate (jt/local-date mindate)
                                                    :parsed-maxdate (jt/local-date maxdate)}
-                                                  (catch Exception _ (-> (res/response {:message "Invalid date format. Date must be in the format YYYY-MM-DD."})
+                                                  (catch Exception _ (-> (res/response {:message "Invalid date format. Date must be in the format yyyy-MM-dd."})
                                                                          (res/status 400))))
         days-between (.until parsed-mindate parsed-maxdate java.time.temporal.ChronoUnit/DAYS)
         results (analytics/weekly-growth-averages ds mindate maxdate {:creator-id (:id user)
-                                                                      :feed-id feed})
-        indexed-results (mapv (fn [{:keys [impressions clicks views]} i]
-                                {:week (str "week " i)
-                                 :impressions impressions
-                                 :clicks clicks
-                                 :views views}) results (range 1 (inc (count results))))]
+                                                                      :feed-id feed})]
     (if (>= days-between 14)
-      (res/response indexed-results)
+      (res/response results)
       (-> (res/response {:message "Date range too small. Date range must include at least 2 weeks."})
           (res/status 400)))))

--- a/src/source/routes/analytics/creator/deltas.clj
+++ b/src/source/routes/analytics/creator/deltas.clj
@@ -18,5 +18,11 @@
 
   [{:keys [ds user query-params] :as _request}]
   (let [{:keys [mindate maxdate feed]} (w/keywordize-keys query-params)]
-    (res/response (analytics/weekly-growth-averages ds mindate maxdate {:creator-id (:id user)
-                                                                        :feed-id feed}))))
+    (let [results (analytics/weekly-growth-averages ds mindate maxdate {:creator-id (:id user)
+                                                                        :feed-id feed})
+          indexed-results (mapv (fn [{:keys [impressions clicks views]} i]
+                                  {:week (str "week " i)
+                                   :impressions impressions
+                                   :clicks clicks
+                                   :views views}) results (range 1 (inc (count results))))]
+      (res/response indexed-results))))

--- a/src/source/routes/analytics/creator/general.clj
+++ b/src/source/routes/analytics/creator/general.clj
@@ -4,7 +4,8 @@
             [clojure.walk :as w]))
 
 (defn get
-  {:summary "Gets the number of impressions, clicks and views per day for a creator over the given time period. Optionally filtered by feed."
+  {:summary "Gets the number of impressions, clicks and views per day for a creator over the given time period. Optionally filtered by feed.
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]

--- a/src/source/routes/analytics/creator/top.clj
+++ b/src/source/routes/analytics/creator/top.clj
@@ -17,7 +17,8 @@
           (services/bundles ds {:where [:in :id ids]}))))
 
 (defn get
-  {:summary "Get the top n records with the highest number of impressions, clicks and views, in terms of the given top field. Optionally filtered by content type."
+  {:summary "Get the top n records with the highest number of impressions, clicks and views, in terms of the given top field. Optionally filtered by content type.
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:n :int]
                         [:mindate :string]

--- a/src/source/routes/analytics/creator/top_average.clj
+++ b/src/source/routes/analytics/creator/top_average.clj
@@ -4,7 +4,8 @@
             [source.util :as utils]))
 
 (defn get
-  {:summary "Get the average engagement (clicks and views) for a creator, optionally filtered by content type."
+  {:summary "Get the average engagement (clicks and views) for a creator, optionally filtered by content type.
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]

--- a/src/source/routes/analytics/distributor/general.clj
+++ b/src/source/routes/analytics/distributor/general.clj
@@ -4,7 +4,8 @@
             [clojure.walk :as w]))
 
 (defn get
-  {:summary "Gets the number of impressions, clicks and views per day for a distributor over the given time period. Optionally filtered by bundle."
+  {:summary "Gets the number of impressions, clicks and views per day for a distributor over the given time period. Optionally filtered by bundle.
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]

--- a/src/source/routes/analytics/distributor/top.clj
+++ b/src/source/routes/analytics/distributor/top.clj
@@ -12,7 +12,8 @@
     (services/feeds ds {:where [:in :id ids]})))
 
 (defn get
-  {:summary "Get the top n records with the highest number of impressions, clicks and views, in terms of the given top field. Optionally filtered by content type."
+  {:summary "Get the top n records with the highest number of impressions, clicks and views, in terms of the given top field. Optionally filtered by content type.
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:n :int]
                         [:mindate :string]

--- a/src/source/routes/analytics/distributor/top_average.clj
+++ b/src/source/routes/analytics/distributor/top_average.clj
@@ -4,7 +4,8 @@
             [source.util :as utils]))
 
 (defn get
-  {:summary "Get the average engagement (clicks and views) for a distributor, optionally filtered by content type."
+  {:summary "Get the average engagement (clicks and views) for a distributor, optionally filtered by content type.
+   Date must be in the format yyyy-MM-dd"
    :parameters {:query [:map
                         [:mindate :string]
                         [:maxdate :string]

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -94,7 +94,13 @@
   Can be filtered by any other arguments accepted by metric-query."
   [ds min-date max-date opts]
   (let [weeks (interval-statistics-query ds :weekly min-date max-date opts)
-        {:keys [impressions clicks views]} (first weeks)]
+        {:keys [impressions clicks views]} (first weeks)
+        {:keys [impressions clicks views]} (cond-> {:impressions impressions
+                                                    :clicks clicks
+                                                    :views views}
+                                             (= impressions 0) (assoc :impressions 1)
+                                             (= clicks 0) (assoc :clicks 1)
+                                             (= views 0) (assoc :views 1))]
     (mapv (fn [w]
             {:week (:week w)
              :impressions (float (* (/ (- (:impressions w) impressions) impressions) 100))

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -93,7 +93,14 @@
   Uses the first week as a basis for comparison.
   Can be filtered by any other arguments accepted by metric-query."
   [ds min-date max-date opts]
-  (let [weeks (interval-statistics-query ds :weekly min-date max-date opts)
+  (let [days (interval-statistics-query ds :daily min-date max-date opts)
+        parts (partition-all 7 days)
+        weeks (mapv (fn [week i]
+                      {:week (str "week " i)
+                       :impressions (apply + (mapv :impressions week))
+                       :clicks (apply + (mapv :clicks week))
+                       :views (apply + (mapv :views week))})
+                    parts (range 1 (inc (count parts))))
         {:keys [impressions clicks views]} (first weeks)
         {:keys [impressions clicks views]} (cond-> {:impressions impressions
                                                     :clicks clicks
@@ -386,6 +393,22 @@
                                   :distributor-id 1}}))
 
   (time (top-statistics-query ds "2025-11-17" "2025-11-24" 10 :post-id {}))
+
+  (def data [{:a 1 :n 64}
+             {:a 2 :n 65}
+             {:a 3 :n 66}
+             {:a 4 :n 67}
+             {:a 5 :n 68}
+             {:a 6 :n 69}
+             {:a 7 :n 70}
+             {:a 8 :n 71}
+             {:a 9 :n 72}
+             {:a 10 :n 73}])
+
+  (mapv (fn [week i]
+          {:week i
+           :n (apply + (mapv :n week))})
+        (partition-all 7 data) (range 1 (inc (count (partition-all 7 data)))))
 
   ())
 

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -9,6 +9,7 @@
   "Generic select query function for returning analytics data from the events table"
   [ds {:keys [select order-by group-by limit metric feed-id post-id content-type-id bundle-id creator-id distributor-id min-date max-date category-ids where ret]}]
   (let [clauses (cond-> {}
+                  (some? where) (merge where)
                   (some? metric) (hsql/where [:= :event metric])
                   (some? feed-id) (hsql/where [:= :feed-id feed-id])
                   (some? post-id) (hsql/where [:= :post-id post-id])
@@ -16,7 +17,6 @@
                   (some? bundle-id) (hsql/where [:= :bundle-id bundle-id])
                   (some? creator-id) (hsql/where [:= :creator-id creator-id])
                   (some? distributor-id) (hsql/where [:= :distributor-id distributor-id])
-                  (some? where) (merge where)
                   (and (some? min-date) (nil? max-date)) (hsql/where [:>= :timestamp min-date])
                   (and (some? max-date) (nil? min-date)) (hsql/where [:<= :timestamp max-date])
                   (and (some? min-date) (some? max-date)) (hsql/where [:between :timestamp min-date max-date])
@@ -315,7 +315,7 @@
       (seed-event! maximums)))
 
   (time (metric-query ds {:min-date "2025-11-25T15:00:00Z"
-                          :feed-id "1"}))
+                          :feed-id 2}))
 
   (time (statistics-query ds {:ret :*}))
 
@@ -355,7 +355,7 @@
 
   (time (weekly-growth-averages ds "2025-11-01" "2025-11-30" {:feed-id 4}))
 
-  (time (average-engagement ds "2025-11-24T00:00:00Z" "2025-11-24T23:59:59Z" {:feed-id 4}))
+  (time (average-engagement ds "2025-11-24" "2025-11-30" {:feed-id 4}))
 
   (time (click-through-rate ds {:min-date "2025-11-24T00:00:00Z"
                                 :max-date "2025-11-24T23:59:59Z"
@@ -387,7 +387,7 @@
                                   :bundle-id 1
                                   :distributor-id 1}}))
 
-  (time (top-statistics-query ds "2025-11-17" "2025-11-24" 10 :post-id {}))
+  (time (top-statistics-query ds "2025-11-17" "2025-11-24" 10 :post-id {:content-type-id 3}))
 
   (def data [{:a 1 :n 64}
              {:a 2 :n 65}
@@ -404,6 +404,19 @@
           {:week i
            :n (apply + (mapv :n week))})
         (partition-all 7 data) (range 1 (inc (count (partition-all 7 data)))))
+
+  (metric-query ds (merge {:select (hsql/select :post-id
+                                                [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]
+                                                [(hsql/filter :%count.* (hsql/where := :event "click")) :clicks]
+                                                [(hsql/filter :%count.* (hsql/where := :event "view")) :views])
+                           :min-date "2025-11-17"
+                           :max-date "2025-11-24"
+                           :where (hsql/where [:!= :post-id nil])
+                           :group-by (hsql/group-by :post-id)
+                           :order-by (hsql/order-by [:impressions :desc] [:clicks :desc] [:views :desc])
+                           :limit 10
+                           :ret :*}
+                          {:content-type-id 3}))
 
   ())
 

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -3,7 +3,8 @@
             [source.db.honey :as hon]
             [source.services.bundles :as bundles]
             [source.util :as util]
-            [source.services.feed-categories :as feed-categories]))
+            [source.services.feed-categories :as feed-categories]
+            [honey.sql :as sql]))
 
 (defn metric-query
   "Generic select query function for returning analytics data from the events table"
@@ -66,7 +67,7 @@
                                                   [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]
                                                   [(hsql/filter :%count.* (hsql/where := :event "click")) :clicks]
                                                   [(hsql/filter :%count.* (hsql/where := :event "view")) :views])
-                             :min-date (str min-date "T00:00:00Z")
+                             :min-date (str min-date)
                              :max-date (str max-date "T23:59:59Z")
                              :group-by (hsql/group-by column)
                              :order-by (hsql/order-by column)}
@@ -270,8 +271,7 @@
     (insert-post-event-categories! ds event' post)))
 
 (comment
-  (require '[source.db.util :as db.util]
-           '[honey.sql :as sql])
+  (require '[source.db.util :as db.util])
 
   (defonce ds (db.util/conn))
 
@@ -337,7 +337,7 @@
                              (hsql/group-by :day)
                              (hsql/order-by :day)) {:ret :*}))
 
-  (time (interval-statistics-query ds :daily "2025-11-17" "2025-11-24" {:feed-id 4}))
+  (time (interval-statistics-query ds :daily "2025-11-17" "2025-11-24" {}))
 
   (time (hon/execute! ds (-> (hsql/select [[:strftime "%W" :timestamp] :week]
                                           [(hsql/filter :%count.* (hsql/where := :event "impression")) :impressions]

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -102,17 +102,12 @@
                        :views (apply + (mapv :views week))})
                     parts (range 1 (inc (count parts))))
         {:keys [impressions clicks views]} (first weeks)
-        {:keys [impressions clicks views]} (cond-> {:impressions impressions
-                                                    :clicks clicks
-                                                    :views views}
-                                             (= impressions 0) (assoc :impressions 1)
-                                             (= clicks 0) (assoc :clicks 1)
-                                             (= views 0) (assoc :views 1))]
+        denom #(if (= % 0) 1 %)]
     (mapv (fn [w]
             {:week (:week w)
-             :impressions (float (* (/ (- (:impressions w) impressions) impressions) 100))
-             :clicks (float (* (/ (- (:clicks w) clicks) clicks) 100))
-             :views (float (* (/ (- (:views w) views) views) 100))})
+             :impressions (float (* (/ (- (:impressions w) impressions) (denom impressions)) 100))
+             :clicks (float (* (/ (- (:clicks w) clicks) (denom clicks)) 100))
+             :views (float (* (/ (- (:views w) views) (denom views)) 100))})
           weeks)))
 
 (defn average-engagement


### PR DESCRIPTION
- Fixed divide by zero bug
- Fixed how weeks are determined, weeks no longer require a monday to be considered a week
- Fixed week indexes to start from 1 instead of being relative to the year
- Added 400 error messages for invalid date format or date range too small
- Updated endpoint description on all analytics endpoints to indicate date format
- Fixed mindate being exclusive