### PR TITLE
prevent duplicate rss feeds

### DIFF
--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -3,7 +3,8 @@
             [source.util :as utils]
             [congest.jobs :as congest]
             [source.jobs.core :as jobs]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [source.jobs.handlers :as handlers]))
 
 (defn get
   {:summary "get all feeds"
@@ -58,59 +59,65 @@
   [{:keys [js ds store user body] :as _request}]
   (let [{:keys [provider-id rss-url content-type-id]} body
         datetime (utils/get-utc-timestamp-string)
-        selection-schemas (->> [:= :provider-id provider-id]
-                               (assoc {} :where)
-                               (services/selection-schemas ds))
-        latest-ss (->> selection-schemas
-                       (reduce (fn [acc {:keys [id]}]
-                                 (conj acc id)) [])
-                       (apply max -1))
-        extracted (when-not (= latest-ss -1)
-                    (services/extract-data store {:schema-id latest-ss
-                                                  :url rss-url}))
-        extracted-posts (get-in extracted [:feed :posts])
-        new-feed (services/insert-feed!
+        used-feed (services/feeds {:where [:= :rss-url rss-url]
+                                   :ret :1})]
+    (if (some? used-feed)
+      (-> (res/response {:message "There is already a feed with the given RSS feed"})
+          (res/status 400))
+
+      (let [selection-schemas (->> [:= :provider-id provider-id]
+                                   (assoc {} :where)
+                                   (services/selection-schemas ds))
+            latest-ss (->> selection-schemas
+                           (reduce (fn [acc {:keys [id]}]
+                                     (conj acc id)) [])
+                           (apply max -1))
+            extracted (when-not (= latest-ss -1)
+                        (services/extract-data store {:schema-id latest-ss
+                                                      :url rss-url}))
+            extracted-posts (get-in extracted [:feed :posts])
+            new-feed (services/insert-feed!
+                      ds
+                      {:data (merge body {:title (get-in extracted [:feed :title])
+                                          :display-picture (get-in extracted [:feed :display-picture])
+                                          :user-id (:id user)
+                                          :created-at datetime
+                                          :state "pending"})})
+            extended-posts (mapv (fn [post]
+                                   (merge post
+                                          {:feed-id (:id new-feed)
+                                           :creator-id (:id user)
+                                           :content-type-id content-type-id
+                                           :thumbnail (or (:thumbnail post) (:display-picture new-feed))}))
+                                 extracted-posts)
+            {:keys [email]} (services/user ds {:id (:id user)})]
+
+        (if (some? extracted-posts)
+          (do
+            (services/insert-incoming-post! ds {:data extended-posts})
+
+            (->> (jobs/prepare-congest-metadata
                   ds
-                  {:data (merge body {:title (get-in extracted [:feed :title])
-                                      :display-picture (get-in extracted [:feed :display-picture])
-                                      :user-id (:id user)
-                                      :created-at datetime
-                                      :state "pending"})})
-        extended-posts (mapv (fn [post]
-                               (merge post
-                                      {:feed-id (:id new-feed)
-                                       :creator-id (:id user)
-                                       :content-type-id content-type-id
-                                       :thumbnail (or (:thumbnail post) (:display-picture new-feed))}))
-                             extracted-posts)
-        {:keys [email]} (services/user ds {:id (:id user)})]
+                  store
+                  {:id (handlers/update-feed-posts-job-id email (:id new-feed))
+                   :initial-delay (* 1000 60 60 24)
+                   :auto-start true
+                   :stop-after-fail false,
+                   :interval (* 1000 60 60 24)
+                   :recurring? true
+                   :args {:feed-id (:id new-feed)
+                          :creator-id (:id user)
+                          :content-type-id content-type-id
+                          :provider-id provider-id
+                          :url rss-url}
+                   :handler :update-feed-posts
+                   :created-at (utils/get-utc-timestamp-string)
+                   :sleep false})
+                 (congest/register! js))
+            (res/response new-feed))
 
-    (if (some? extracted-posts)
-      (do
-        (services/insert-incoming-post! ds {:data extended-posts})
-
-        (->> (jobs/prepare-congest-metadata
-              ds
-              store
-              {:id (str email "-" (:id new-feed))
-               :initial-delay (* 1000 60 60 24)
-               :auto-start true
-               :stop-after-fail false,
-               :interval (* 1000 60 60 24)
-               :recurring? true
-               :args {:feed-id (:id new-feed)
-                      :creator-id (:id user)
-                      :content-type-id content-type-id
-                      :provider-id provider-id
-                      :url rss-url}
-               :handler :update-feed-posts
-               :created-at (utils/get-utc-timestamp-string)
-               :sleep false})
-             (congest/register! js))
-        (res/response new-feed))
-
-      (-> (res/response {:message "failed to extract data"})
-          (res/status 500)))))
+          (-> (res/response {:message "failed to extract data"})
+              (res/status 500)))))))
 
 (comment
   (require '[source.db.util :as db.util]

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -4,7 +4,7 @@
             [congest.jobs :as congest]
             [source.jobs.core :as jobs]
             [ring.util.response :as res]
-            [source.jobs.handlers :as handlers]))
+            [source.db.honey :as hon]))
 
 (defn get
   {:summary "get all feeds"
@@ -59,9 +59,10 @@
   [{:keys [js ds store user body] :as _request}]
   (let [{:keys [provider-id rss-url content-type-id]} body
         datetime (utils/get-utc-timestamp-string)
-        used-feed (services/feeds {:where [:= :rss-url rss-url]
-                                   :ret :1})]
-    (if (some? used-feed)
+        exists (hon/exists? ds {:tname :feeds
+                                :where [:= :rss-url rss-url]
+                                :ret :1})]
+    (if exists
       (-> (res/response {:message "There is already a feed with the given RSS feed"})
           (res/status 400))
 
@@ -99,7 +100,7 @@
             (->> (jobs/prepare-congest-metadata
                   ds
                   store
-                  {:id (handlers/update-feed-posts-job-id email (:id new-feed))
+                  {:id (str email "-" (:id new-feed))
                    :initial-delay (* 1000 60 60 24)
                    :auto-start true
                    :stop-after-fail false,


### PR DESCRIPTION
Fixed a bug where creators are able to create more than 1 feed with the same RSS feed.
