### PR TITLE
delete feed endpoint

### DIFF
--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -18,6 +18,11 @@
   (fn [{:keys [args]}]
     (println "hello" (get args :name) args)))
 
+(defn update-feed-posts-job-id 
+  "returns the job id of an update-feed-posts job with the given email and feed-id"
+  [email feed-id]
+  (str email "-" feed-id))
+
 (defmethod handler :update-feed-posts [_]
   (fn [{:keys [args ds store]}]
     (try
@@ -62,6 +67,11 @@
              (services/insert-incoming-post! ds {:data post})))
          extended-posts))
       (catch Exception _ :fail))))
+
+(defn update-bundle-job-id 
+  "returns the job id of an update-bundle job with the given bundle id"
+  [bundle-id]
+  (str "bundle_" bundle-id))
 
 ; run long heuristics and pull the highest scoring incoming posts into the bundle's outgoing posts
 (defmethod handler :update-bundle [_]

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -43,12 +43,15 @@
           start (when start (try (Integer/parseInt start) (catch Exception _)))
           limit (when limit (try (Integer/parseInt limit) (catch Exception _)))
 
+          all-feed-ids (mapv :id (services/feeds ds))
           blocked-feed-ids (mapv :feed-id (services/filtered-feeds ds {:where [:= :bundle-id bundle-id]}))
+          available-feed-ids (vec (remove (set blocked-feed-ids) all-feed-ids))
+
           blocked-post-ids (mapv :post-id (services/filtered-posts ds {:where [:= :bundle-id bundle-id]}))
 
           filtered-posts (services/outgoing-posts bundle-ds (-> (hsql/where content-type-comp
                                                                             [:not [:in :id blocked-post-ids]]
-                                                                            [:not [:in :feed-id blocked-feed-ids]])
+                                                                            [:in :feed-id available-feed-ids])
                                                                 (hsql/order-by (when (= latest "true") [[:posted-at :desc]]))))
 
           categorised-posts (vec

--- a/src/source/routes/feed.clj
+++ b/src/source/routes/feed.clj
@@ -1,6 +1,9 @@
 (ns source.routes.feed
   (:require [source.services.interface :as services]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [congest.jobs :as congest]
+            [source.jobs.handlers :as handlers]
+            [source.services.analytics.interface :as analytics]))
 
 (defn get
   {:summary "get feed by id"
@@ -45,3 +48,28 @@
   (services/update-feed! ds {:id (:id path-params)
                              :data body})
   (res/response {:message "successfully updated feed"}))
+
+(defn hard-delete-feed! [ds js creator-email feed-id]
+  (let [job-id (handlers/update-feed-posts-job-id creator-email feed-id)
+        post-ids (mapv :id (services/incoming-posts ds {:where [:= :feed-id feed-id]}))]
+    (services/delete-filtered-feed! ds {:where [:= :feed-id feed-id]})
+    (services/delete-filtered-post! ds {:where [:in :post-id post-ids]})
+    (services/delete-incoming-post! ds {:where [:= :feed-id feed-id]})
+    (services/delete-feed-category! ds {:where [:= :feed-id feed-id]})
+    (analytics/delete-event! ds {:where [:= :feed-id feed-id]})
+    (services/delete-feed! ds {:where [:= :id feed-id]})
+    (congest/deregister! js job-id)))
+
+(defn delete
+  {:summary "delete feed by id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "feed id"} :int]]}
+   :responses {200 {:body [:map [:message :string]]}
+               401 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds js user path-params] :as _request}]
+  (let [id (:id path-params)
+        {:keys [email]} (services/user ds {:id (:id user)})]
+    (hard-delete-feed! ds js email id)
+    (res/response {:message "successfully deleted feed"})))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -4,7 +4,8 @@
             [source.db.util :as db.util]
             [congest.jobs :as congest]
             [source.util :as utils]
-            [source.jobs.core :as jobs]))
+            [source.jobs.core :as jobs]
+            [source.jobs.handlers :as handlers]))
 
 (defn get
   {:summary "get integration by id"

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -5,7 +5,8 @@
             [source.migrate :as migrate]
             [congest.jobs :as congest]
             [source.jobs.core :as jobs]
-            [source.db.util :as db.util]))
+            [source.db.util :as db.util]
+            [source.jobs.handlers :as handlers]))
 
 (defn get
   {:summary "get all integrations"
@@ -82,7 +83,7 @@
     (->> (jobs/prepare-congest-metadata
           ds
           store
-          {:id (str "bundle_" (:id new-bundle))
+          {:id (handlers/update-bundle-job-id (:id new-bundle))
            :initial-delay 0
            :auto-start true
            :stop-after-fail false,

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -213,7 +213,8 @@
                                 :post feeds/post})]
       ["/:id"
        [""              (route {:get feed/get
-                                :post feed/post})]
+                                :post feed/post
+                                :delete feed/delete})]
        ["/posts"
         [""             (route {:get posts/get})]
         ["/:post-id"

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -131,6 +131,15 @@
        (merge opts)
        (hon/insert! ds)))
 
+(defn delete-event! [ds {:keys [id where] :as opts}]
+  (->> {:tname :events
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (hon/delete! ds)))
+
 (defn insert-feed-event-categories!
   "Given a list of events and a list of feeds (or a single event/feed), 
   inserts an event category record for each event and each category 

--- a/src/source/services/analytics/interface.clj
+++ b/src/source/services/analytics/interface.clj
@@ -48,6 +48,9 @@
 (defn insert-event-categories! [ds {:keys [_data _ret] :as opts}]
   (core/insert-event-categories! ds opts))
 
+(defn delete-event! [ds {:keys [_id _where] :as opts}]
+  (core/delete-event! ds opts))
+
 (defn insert-feed-event-categories!
   "Given a list of events and a list of feeds (or a single event/feed), 
   inserts an event category record for each event and each category 

--- a/src/source/services/feeds.clj
+++ b/src/source/services/feeds.clj
@@ -33,3 +33,12 @@
         :ret :1}
        (merge opts)
        (db/find ds)))
+
+(defn delete-feed! [ds {:keys [id where] :as opts}]
+  (->> {:tname :feeds
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))

--- a/src/source/services/incoming_posts.clj
+++ b/src/source/services/incoming_posts.clj
@@ -55,3 +55,12 @@
                   :right-join [:categories [:= :categories.id :feed-categories.category-id]]}
                  opts)
                 {:ret :*}))
+
+(defn delete-incoming-post! [ds {:keys [id where] :as opts}]
+  (->> {:tname :incoming-posts
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -197,6 +197,9 @@
 (defn feed [ds {:keys [_id] :as opts}]
   (feeds/feed ds opts))
 
+(defn delete-feed! [ds {:keys [_id _where] :as opts}]
+  (feeds/delete-feed! ds opts))
+
 (defn insert-incoming-post! [ds {:keys [_data _ret] :as opts}]
   (incoming-posts/insert-incoming-post! ds opts))
 
@@ -215,6 +218,9 @@
 
 (defn incoming-post [ds opts]
   (incoming-posts/incoming-post ds opts))
+
+(defn delete-incoming-post! [ds {:keys [_id _where] :as opts}]
+  (incoming-posts/delete-incoming-post! ds opts))
 
 (defn insert-cadence! [ds {:keys [_values _ret] :as opts}]
   (cadences/insert-cadence! ds opts))


### PR DESCRIPTION
- added services to allow deletion on multiple different tables related to feeds
- added functions to resolve job names
- added endpoint to delete feed
- updated bundle posts endpoint to ensure posts from deleted feeds aren't fetched
- updated integration endpoints to use job name resolution functions
