### PR TITLE
delete integration endpoint

### DIFF
--- a/src/source/routes/feed.clj
+++ b/src/source/routes/feed.clj
@@ -70,6 +70,13 @@
 
   [{:keys [ds js user path-params] :as _request}]
   (let [id (:id path-params)
+        feed (services/feed ds {:where [:and
+                                        [:= :user-id (:id user)
+                                         := :id id]]})
         {:keys [email]} (services/user ds {:id (:id user)})]
-    (hard-delete-feed! ds js email id)
-    (res/response {:message "successfully deleted feed"})))
+    (if (some? feed)
+      (do
+        (hard-delete-feed! ds js email id)
+        (res/response {:message "successfully deleted feed"}))
+      (-> (res/response {:message "unauthorized"})
+          (res/status 403)))))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -5,7 +5,9 @@
             [congest.jobs :as congest]
             [source.util :as utils]
             [source.jobs.core :as jobs]
-            [source.jobs.handlers :as handlers]))
+            [source.jobs.handlers :as handlers]
+            [source.services.analytics.interface :as analytics]
+            [source.db.tables :as tables]))
 
 (defn get
   {:summary "get integration by id"
@@ -97,3 +99,23 @@
          (congest/register! js))
 
     (res/response {:message "successfully updated integration"})))
+
+(defn hard-delete-bundle! [ds js bundle-id]
+  (let [job-id (handlers/update-bundle-job-id bundle-id)]
+    (services/delete-filtered-feed! ds {:where [:= :bundle-id bundle-id]})
+    (services/delete-filtered-post! ds {:where [:= :bundle-id bundle-id]})
+    (services/delete-bundle-content-types! ds {:where [:= :bundle-id bundle-id]})
+    (analytics/delete-event! ds {:where [:= :bundle-id bundle-id]})
+    (tables/drop-all-tables! (db.util/conn :bundle bundle-id))
+    (services/delete-bundle ds {:id bundle-id})
+    (congest/deregister! js job-id)))
+
+(defn delete
+  {:summary "delete the integration with the given id"
+   :parameters {:path [:map [:id {:title "id"
+                                  :description "integration id"} :int]]}
+   :responses {200 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds js path-params] :as _request}]
+    (hard-delete-bundle! ds js (:id path-params))
+    (res/response {:message "successfully deleted integration"}))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -114,8 +114,16 @@
   {:summary "delete the integration with the given id"
    :parameters {:path [:map [:id {:title "id"
                                   :description "integration id"} :int]]}
-   :responses {200 {:body [:map [:message :string]]}}}
+   :responses {200 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
 
-  [{:keys [ds js path-params] :as _request}]
-    (hard-delete-bundle! ds js (:id path-params))
-    (res/response {:message "successfully deleted integration"}))
+  [{:keys [ds js user path-params] :as _request}]
+  (let [bundle (services/bundle ds {:where [:and
+                                            [:= :id (:id path-params)]
+                                            [:= :user-id (:id user)]]})]
+    (if (some? bundle)
+      (do
+        (hard-delete-bundle! ds js (:id path-params))
+        (res/response {:message "successfully deleted integration"}))
+      (-> (res/response {:message "unauthorized"})
+          (res/status 403)))))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -195,7 +195,8 @@
                                 :post integrations/post})]
       ["/:id"
        [""              (route {:get integration/get
-                                :post integration/post})]
+                                :post integration/post
+                                :delete integration/delete})]
        ["/key"          (route {:post integration-key/post})]
        ["/categories"   (route {:get integration-categories/get
                                 :post integration-categories/post})]

--- a/src/source/services/bundles.clj
+++ b/src/source/services/bundles.clj
@@ -31,3 +31,12 @@
         :ret :1}
        (merge opts)
        (db/find ds)))
+
+(defn delete-bundle! [ds {:keys [id where] :as opts}]
+  (->> {:tname :bundles
+        :where (if (some? id)
+                 [:= :id id]
+                 where)
+        :ret :1}
+       (merge opts)
+       (db/delete! ds)))

--- a/src/source/services/interface.clj
+++ b/src/source/services/interface.clj
@@ -72,6 +72,9 @@
 (defn bundle [ds {:keys [_id _where] :as opts}]
   (bundles/bundle ds opts))
 
+(defn delete-bundle [ds {:keys [_id _where] :as opts}]
+  (bundles/delete-bundle! ds opts))
+
 (defn bundle-categories
   ([ds] (bundle-categories ds {}))
   ([ds {:keys [_where] :as opts}]


### PR DESCRIPTION
- Added endpoint to allow distributors to hard delete their integrations
- Fixed a bug where creators were able to delete feeds that aren't theirs