### PR TITLE
user deletion

### DIFF
--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -1,7 +1,5 @@
 (ns source.db.master
-  (:require [source.db.tables :as tables]
-            [source.db.honey :as hon]
-            [source.db.util :as db.util]))
+  (:require [source.db.tables :as tables]))
 
 (def users
   (tables/create-table-sql
@@ -80,21 +78,21 @@
 
 (def filtered-feeds
   (tables/create-table-sql
-    :filtered-feeds
-    (tables/table-id)
-    [:feed-id :integer :not nil]
-    [:bundle-id :integer :not nil]
-    (tables/foreign-key :feed-id :feeds :id)
-    (tables/foreign-key :bundle-id :bundles :id)))
+   :filtered-feeds
+   (tables/table-id)
+   [:feed-id :integer :not nil]
+   [:bundle-id :integer :not nil]
+   (tables/foreign-key :feed-id :feeds :id)
+   (tables/foreign-key :bundle-id :bundles :id)))
 
 (def filtered-posts
   (tables/create-table-sql
-    :filtered-posts
-    (tables/table-id)
-    [:post-id :integer :not nil]
-    [:bundle-id :integer :not nil]
-    (tables/foreign-key :post-id :incoming-posts :id)
-    (tables/foreign-key :bundle-id :bundles :id)))
+   :filtered-posts
+   (tables/table-id)
+   [:post-id :integer :not nil]
+   [:bundle-id :integer :not nil]
+   (tables/foreign-key :post-id :incoming-posts :id)
+   (tables/foreign-key :bundle-id :bundles :id)))
 
 (def feeds
   (tables/create-table-sql
@@ -252,9 +250,9 @@
 
 (def business-types
   (tables/create-table-sql
-    :business-types 
-    (tables/table-id)
-    [:name :text :not nil]))
+   :business-types
+   (tables/table-id)
+   [:name :text :not nil]))
 
 (comment
   (require '[honey.sql :as sql])

--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -1,5 +1,7 @@
 (ns source.db.master
-  (:require [source.db.tables :as tables]))
+  (:require [source.db.tables :as tables]
+            [source.db.honey :as hon]
+            [source.db.util :as db.util]))
 
 (def users
   (tables/create-table-sql

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -28,10 +28,7 @@
 (defmethod handler :update-feed-posts [_]
   (fn [{:keys [args ds store]}]
     (try
-      (when (-> (hon/find ds {:tname :users
-                              :where [:= :id (:creator-id args)]})
-                (:removed)
-                (= 0))
+      (when (users/removed? ds (:creator-id args))
         (let [{:keys [feed-id creator-id content-type-id provider-id url]} args
               selection-schemas (->> [:= :provider-id provider-id]
                                      (assoc {} :where)
@@ -124,9 +121,16 @@
             posts-in (hon/find ds {:tname :incoming-posts
                                    :where [:in :id ids]})
 
+            creator-ids (mapv :creator-id posts-in)
+            active-creator-ids (->> (hon/find ds {:tname :users
+                                                  :where [:in :id creator-ids]})
+                                    (filterv #(or (nil? (:removed %)) (= (:removed %) 0)))
+                                    (mapv :id))
+
             ; remove redacted posts
-            outgoing-posts (reduce (fn [acc {:keys [redacted] :as post}]
-                                     (if (:= redacted 0)
+            outgoing-posts (reduce (fn [acc {:keys [redacted creator-id] :as post}]
+                                     (if (and (or (nil? redacted) (= redacted 0))
+                                              (some #{creator-id} active-creator-ids))
                                        (conj acc (dissoc post :redacted))
                                        acc))
                                    [] posts-in)]

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -29,51 +29,56 @@
 (defmethod handler :update-feed-posts [_]
   (fn [{:keys [args ds store]}]
     (try
-      (let [{:keys [feed-id creator-id content-type-id provider-id url]} args
-            selection-schemas (->> [:= :provider-id provider-id]
-                                   (assoc {} :where)
-                                   (services/selection-schemas ds))
-            latest-ss (->> selection-schemas
-                           (reduce (fn [acc {:keys [id]}]
-                                     (conj acc id)) [])
-                           (apply max -1))
-            extracted (services/extract-data store {:schema-id latest-ss
-                                                    :url url})
-            extracted-posts (get-in extracted [:feed :posts])
-            extracted-display (get-in extracted [:feed :display-picture])
-            extended-posts (mapv (fn [{:keys [posted-at thumbnail] :as post}]
-                                   (merge post
-                                          {:feed-id feed-id
-                                           :creator-id creator-id
-                                           :content-type-id content-type-id
-                                           :posted-at (util/format-rss-date posted-at)
-                                           :thumbnail (if (and thumbnail
-                                                               (seq thumbnail)
-                                                               (not (string/includes? thumbnail ".mp3")))
-                                                        thumbnail
-                                                        extracted-display)}))
-                                 extracted-posts)
-            existing-posts (hon/find ds {:tname :incoming-posts
-                                         :where [:= :creator-id creator-id]})
-            existing-feed (hon/find-one ds {:tname :feeds
-                                            :where [:= :id feed-id]})]
-        (hon/update! ds {:tname :feeds
-                         :where [:= :id feed-id]
-                         :data {:title (get-in extracted [:feed :title])
-                                :display-picture (if (and (:display-picture existing-feed)
-                                                          (seq (:display-picture existing-feed)))
-                                                   (:display-picture existing-feed)
-                                                   extracted-display)
-                                :updated-at (util/get-utc-timestamp-string)}})
-        (run!
-         (fn [post]
-           (if (some #(= (:post-id post) (:post-id %)) existing-posts)
-             (hon/update! ds {:tname :incoming-posts
-                              :where [:= :post-id (:post-id post)]
-                              :data post})
-             (hon/insert! ds {:tname :incoming-posts
-                              :data post})))
-         extended-posts))
+      (when (-> (hon/find ds {:tname :users
+                              :where [:= :id (:creator-id args)]})
+                (:removed)
+                (= 0))
+        (let [{:keys [feed-id creator-id content-type-id provider-id url]} args
+              selection-schemas (->> [:= :provider-id provider-id]
+                                     (assoc {} :where)
+                                     (services/selection-schemas ds))
+              latest-ss (->> selection-schemas
+                             (reduce (fn [acc {:keys [id]}]
+                                       (conj acc id)) [])
+                             (apply max -1))
+              extracted (services/extract-data store {:schema-id latest-ss
+                                                      :url url})
+              extracted-posts (get-in extracted [:feed :posts])
+              extracted-display (get-in extracted [:feed :display-picture])
+              extended-posts (mapv (fn [{:keys [posted-at thumbnail] :as post}]
+                                     (merge post
+                                            {:feed-id feed-id
+                                             :creator-id creator-id
+                                             :content-type-id content-type-id
+                                             :posted-at (util/format-rss-date posted-at)
+                                             :thumbnail (if (and thumbnail
+                                                                 (seq thumbnail)
+                                                                 (not (string/includes? thumbnail ".mp3")))
+                                                          thumbnail
+                                                          extracted-display)}))
+                                   extracted-posts)
+              existing-posts (hon/find ds {:tname :incoming-posts
+                                           :where [:= :creator-id creator-id]})
+              existing-feed (hon/find-one ds {:tname :feeds
+                                              :where [:= :id feed-id]})]
+          (hon/update! ds {:tname :feeds
+                           :where [:= :id feed-id]
+                           :data {:title (get-in extracted [:feed :title])
+                                  :display-picture (if (and (:display-picture existing-feed)
+                                                            (seq (:display-picture existing-feed)))
+                                                     (:display-picture existing-feed)
+                                                     extracted-display)
+                                  :updated-at (util/get-utc-timestamp-string)}})
+          (run!
+           (fn [post]
+             (if (some #(= (:post-id post) (:post-id %)) existing-posts)
+               (hon/update! ds {:tname :incoming-posts
+                                :where [:= :post-id (:post-id post)]
+                                :data post})
+               (hon/insert! ds {:tname :incoming-posts
+                                :data post})))
+           extended-posts)))
+
       (catch Exception _ :fail))))
 
 (defn update-bundle-job-id
@@ -119,9 +124,10 @@
             ; get all incoming posts with the above id numbers
             posts-in (hon/find ds {:tname :incoming-posts
                                    :where [:in :id ids]})
+
             ; remove redacted posts
             outgoing-posts (reduce (fn [acc {:keys [redacted] :as post}]
-                                     (if (:= redacted 0)
+                                     (if (= redacted 0)
                                        (conj acc (dissoc post :redacted))
                                        acc))
                                    [] posts-in)]

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -6,8 +6,7 @@
             [source.db.util :as db.util]
             [clojure.set :as set]
             [clojure.string :as string]
-            [source.db.honey :as hon]
-            [congest.jobs :as congest]))
+            [source.db.honey :as hon]))
 
 (defmulti handler
   (fn [opts]

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -126,7 +126,7 @@
 
             ; remove redacted posts
             outgoing-posts (reduce (fn [acc {:keys [redacted] :as post}]
-                                     (if (= redacted 0)
+                                     (if (:= redacted 0)
                                        (conj acc (dissoc post :redacted))
                                        acc))
                                    [] posts-in)]

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -1,11 +1,13 @@
 (ns source.jobs.handlers
   (:require [source.services.interface :as services]
+            [source.workers.users :as users]
             [source.util :as util]
             [source.services.incoming-posts :as incoming-posts]
             [source.db.util :as db.util]
             [clojure.set :as set]
             [clojure.string :as string]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [congest.jobs :as congest]))
 
 (defmulti handler
   (fn [opts]
@@ -127,3 +129,15 @@
           (hon/delete! ds-bundle {:tname :outgoing-posts})
           (hon/insert! ds-bundle {:tname :outgoing-posts
                                   :data outgoing-posts}))))))
+
+(defn user-deletion-job-id
+  "returns the job id of a user deletion job with the given user id"
+  [user-type user-id]
+  (str "delete_" user-type "_" user-id))
+
+(defmethod handler :delete-user [_]
+  (fn [{:keys [args ds store]}]
+    (try
+      (let [{:keys [user-type user-id]} args]
+        (users/hard-delete-user! ds store (keyword user-type) user-id))
+      (catch Exception e (println "Failed to delete user: " e) :fail))))

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -50,9 +50,11 @@
   (fn [request]
     (let [ds (db.util/conn :master)
           bundle-uuid (get-in request [:query-params :uuid])
-          {:keys [id]} (db/find-one ds {:tname :bundles
-                                        :where [:= :uuid bundle-uuid]})]
-      (if (some? id)
+          {:keys [id user-id]} (db/find-one ds {:tname :bundles
+                                                :where [:= :uuid bundle-uuid]})
+          {:keys [removed]} (db/find-one ds {:tname :users
+                                             :where [:= :id user-id]})]
+      (if (and (some? id) (= removed 0))
         (-> request
             (assoc :bundle-id id)
             (handler))
@@ -67,8 +69,10 @@
   (fn [request]
     (let [ds (db.util/conn :master)
           token (util/auth-token request)
-          existing-bundle (bundles/bundle ds {:where [:= :hash token]})]
-      (if (some? existing-bundle)
+          {:keys [user-id] :as existing-bundle} (bundles/bundle ds {:where [:= :hash token]})
+          {:keys [removed]} (db/find-one ds {:tname :users
+                                             :where [:= :id user-id]})]
+      (if (and (some? existing-bundle) (= removed 0))
         (-> request
             (assoc :bundle-id (:id existing-bundle))
             (handler))

--- a/src/source/migrations/009_user_removed.clj
+++ b/src/source/migrations/009_user_removed.clj
@@ -1,0 +1,15 @@
+(ns source.migrations.009-user-removed
+  (:require [source.db.master]
+            [source.db.honey :as hon]))
+
+(defn run-up! [context]
+  (let [ds-master (:db-master context)]
+    (->> {:alter-table :users
+          :add-column [:removed :integer [:default 0]]}
+         (hon/execute! ds-master))))
+
+(defn run-down! [context]
+  (let [ds-master (:db-master context)]
+    (->> {:alter-table :users
+          :drop-column :removed}
+         (hon/execute! ds-master))))

--- a/src/source/routes/feed.clj
+++ b/src/source/routes/feed.clj
@@ -1,7 +1,8 @@
 (ns source.routes.feed
   (:require [ring.util.response :as res]
             [source.db.honey :as hon]
-            [source.workers.feeds :as feeds]))
+            [source.workers.feeds :as feeds]
+            [source.jobs.handlers :as handlers]))
 
 (defn get
   {:summary "get feed by id"
@@ -63,10 +64,11 @@
                                        [:= :user-id (:id user)]
                                        [:= :id id]]})
         {:keys [email]} (hon/find-one ds {:tname :users
-                                          :where [:= :id (:id user)]})]
+                                          :where [:= :id (:id user)]})
+        job-id (handlers/update-feed-posts-job-id email id)]
     (if (some? feed)
       (do
-        (feeds/hard-delete-feed! ds js email id)
+        (feeds/hard-delete-feed! ds js job-id id)
         (res/response {:message "successfully deleted feed"}))
       (-> (res/response {:message "unauthorized"})
           (res/status 403)))))

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -2,7 +2,9 @@
   (:require [source.workers.feeds :as feeds]
             [congest.jobs :as congest]
             [ring.util.response :as res]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.util :as util]
+            [source.jobs.core :as jobs]))
 
 (defn get
   {:summary "get all feeds"
@@ -63,10 +65,33 @@
       (-> (res/response {:message "There is already a feed with the given RSS feed"})
           (res/status 400))
 
-      (let [new-feed (feeds/create-feed! ds js store {:user-id (:id user)
-                                                      :feed-metadata body})]
+      (let [{:keys [provider-id rss-url content-type-id]} body
+            new-feed (feeds/create-feed! ds store {:user-id (:id user)
+                                                   :feed-metadata body})
+            {:keys [email]} (hon/find-one ds {:tname :users
+                                              :where [:= :id (:id user)]})]
         (if new-feed
-          (res/response new-feed)
+          (do
+            (->> (jobs/prepare-congest-metadata
+                  ds
+                  store
+                  {:id (str email "-" (:id new-feed))
+                   :initial-delay (* 1000 60 60 24)
+                   :auto-start true
+                   :stop-after-fail false,
+                   :interval (* 1000 60 60 24)
+                   :recurring? true
+                   :args {:feed-id (:id new-feed)
+                          :creator-id (:id user)
+                          :content-type-id content-type-id
+                          :provider-id provider-id
+                          :url rss-url}
+                   :handler :update-feed-posts
+                   :created-at (util/get-utc-timestamp-string)
+                   :sleep false})
+                 (congest/register! js))
+            (res/response new-feed))
+
           (-> (res/response {:message "Failed to parse RSS feed"})
               (res/status 422)))))))
 

--- a/src/source/routes/feeds.clj
+++ b/src/source/routes/feeds.clj
@@ -72,6 +72,7 @@
                                               :where [:= :id (:id user)]})]
         (if new-feed
           (do
+            ;TODO: service needed
             (->> (jobs/prepare-congest-metadata
                   ds
                   store

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -2,7 +2,11 @@
   (:require [ring.util.response :as res]
             [source.services.interface :as services]
             [source.services.bundles :as bundles]
-            [source.workers.integrations :as integrations]))
+            [source.workers.integrations :as integrations]
+            [congest.jobs :as congest]
+            [source.jobs.core :as jobs]
+            [source.util :as util]
+            [source.jobs.handlers :as handlers]))
 
 (defn get
   {:summary "get integration by id"
@@ -50,10 +54,31 @@
                403 {:body [:map [:message :string]]}}}
 
   [{:keys [js ds store path-params body] :as _request}]
-  (integrations/update-integration! ds js store {:bundle-id (:id path-params)
-                                                 :bundle-metadata (dissoc body :categories :content-types)
-                                                 :categories (:categories body)
-                                                 :content-types (:content-types body)})
+  (let [bundle-id (:id path-params)
+        job-id (str "bundle_" bundle-id)
+        categories-by-bundle (bundles/categories-in-bundle ds bundle-id)]
+    (integrations/update-integration! ds {:bundle-id bundle-id
+                                          :bundle-metadata (dissoc body :categories :content-types)
+                                          :categories (:categories body)
+                                          :content-types (:content-types body)})
+    ;TODO: service needed
+    (congest/deregister! js job-id)
+    (->> (jobs/prepare-congest-metadata
+          ds
+          store
+          {:id job-id
+           :initial-delay (* 1000 60 60 24)
+           :auto-start true
+           :stop-after-fail false,
+           :interval (* 1000 60 60 24)
+           :recurring? true
+           :ds ds
+           :args {:bundle-id bundle-id
+                  :categories categories-by-bundle}
+           :handler :update-bundle
+           :created-at (util/get-utc-timestamp-string)
+           :sleep false})
+         (congest/register! js)))
   (res/response {:message "successfully updated integration"}))
 
 (defn delete
@@ -64,12 +89,14 @@
                403 {:body [:map [:message :string]]}}}
 
   [{:keys [ds js user path-params] :as _request}]
-  (let [bundle (bundles/bundle ds {:where [:and
-                                           [:= :id (:id path-params)]
-                                           [:= :user-id (:id user)]]})]
+  (let [bundle-id (:id path-params)
+        bundle (bundles/bundle ds {:where [:and
+                                           [:= :id bundle-id]
+                                           [:= :user-id (:id user)]]})
+        job-id (handlers/update-bundle-job-id bundle-id)]
     (if (some? bundle)
       (do
-        (integrations/hard-delete-bundle! ds js (:id path-params))
+        (integrations/hard-delete-bundle! ds js job-id bundle-id)
         (res/response {:message "successfully deleted integration"}))
       (-> (res/response {:message "unauthorized"})
           (res/status 403)))))

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -1,7 +1,11 @@
 (ns source.routes.integrations
   (:require [ring.util.response :as res]
             [source.services.bundles :as bundles]
-            [source.workers.integrations :as integrations]))
+            [source.workers.integrations :as integrations]
+            [source.util :as util]
+            [source.jobs.core :as jobs]
+            [source.jobs.handlers :as handlers]
+            [congest.jobs :as congest]))
 
 (defn get
   {:summary "get all integrations"
@@ -51,9 +55,27 @@
                403 {:body [:map [:message :string]]}}}
 
   [{:keys [js ds store user body] :as _request}]
-  (->> {:user-id (:id user)
-        :bundle-metadata (dissoc body :categories :content-types)
-        :categories (:categories body)
-        :content-types (:content-types body)}
-       (integrations/create-integration! ds js store)
-       (res/response)))
+  (let [new-bundle (->> {:user-id (:id user)
+                         :bundle-metadata (dissoc body :categories :content-types)
+                         :categories (:categories body)
+                         :content-types (:content-types body)}
+                        (integrations/create-integration! ds))
+        categories-by-bundle (bundles/categories-in-bundle ds (:id new-bundle))]
+    ;TODO: service needed
+    (->> (jobs/prepare-congest-metadata
+          ds
+          store
+          {:id (handlers/update-bundle-job-id (:id new-bundle))
+           :initial-delay 0
+           :auto-start true
+           :stop-after-fail false,
+           :interval (* 1000 60 60 24)
+           :recurring? true
+           :ds ds
+           :args {:bundle-id (:id new-bundle)
+                  :categories categories-by-bundle}
+           :handler :update-bundle
+           :created-at (util/get-utc-timestamp-string)
+           :sleep false})
+         (congest/register! js))
+    (res/response new-bundle)))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -4,7 +4,8 @@
             [source.db.honey :as hon]
             [source.jobs.core :as jobs]
             [source.jobs.handlers :as handlers]
-            [congest.jobs :as congest]))
+            [congest.jobs :as congest]
+            [source.workers.users :as users]))
 
 (defn get
   {:summary "get logged in user by access token"
@@ -58,10 +59,7 @@
   [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
-
-    (hon/update! ds {:tname :users
-                     :where [:= :id id]
-                     :data {:removed 1}})
+    (users/soft-delete-user! ds (keyword type) id)
 
     ; TODO: service needed
     (->> (jobs/prepare-congest-metadata
@@ -89,8 +87,6 @@
   [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
-    (hon/update! ds {:tname :users
-                     :where [:= :id id]
-                     :data {:removed 0}})
+    (users/cancel-soft-user-deletion! ds (keyword type) id)
     (congest/deregister! js job-id)
     (res/response {:message "successfully cancelled user deletion"})))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -58,6 +58,11 @@
   [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
+
+    (hon/update! ds {:tname :users
+                     :where [:= :id id]
+                     :data {:removed 1}})
+
     ; TODO: service needed
     (->> (jobs/prepare-congest-metadata
           ds
@@ -81,8 +86,11 @@
   {:summary "cancel deletion of logged-in user by access token"
    :responses {200 {:body [:map [:message :string]]}}}
 
-  [{:keys [js user] :as _request}]
+  [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
+    (hon/update! ds {:tname :users
+                     :where [:= :id id]
+                     :data {:removed 0}})
     (congest/deregister! js job-id)
     (res/response {:message "successfully cancelled user deletion"})))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -1,7 +1,10 @@
 (ns source.routes.me
   (:require [ring.util.response :as res]
             [source.util :as util]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.jobs.core :as jobs]
+            [source.jobs.handlers :as handlers]
+            [congest.jobs :as congest]))
 
 (defn get
   {:summary "get logged in user by access token"
@@ -47,3 +50,38 @@
                            :where [:= :id (:id user)]
                            :data data})
           (res/response {:message "successfully updated user"})))))
+
+(defn delete-user
+  {:summary "delete logged-in user by access token"
+   :responses {200 {:body [:map [:message :string]]}}}
+
+  [{:keys [ds js user] :as _request}]
+  (let [{:keys [id type]} user
+        job-id (handlers/user-deletion-job-id type id)]
+    (->> (jobs/prepare-congest-metadata
+          ds
+          js
+          {:id job-id
+           :initial-delay (* 1000 60) #_(* 1000 60 60 24 30)
+           :auto-start true
+           :stop-after-fail false,
+           :interval (* 1000 60) #_(* 1000 60 60 24 30)
+           :recurring? false
+           :kill-after 1
+           :args {:user-type type
+                  :user-id id}
+           :handler :delete-user
+           :created-at (util/get-utc-timestamp-string)
+           :sleep false})
+         (congest/register! js))
+    (res/response {:message "successfully scheduled user deletion"})))
+
+(defn cancel-deletion
+  {:summary "cancel deletion of logged-in user by access token"
+   :responses {200 {:body [:map [:message :string]]}}}
+
+  [{:keys [js user] :as _request}]
+  (let [{:keys [id type]} user
+        job-id (handlers/user-deletion-job-id type id)]
+    (congest/deregister! js job-id)
+    (res/response {:message "successfully cancelled user deletion"})))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -59,7 +59,7 @@
   [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
-    (users/soft-delete-user! ds (keyword type) id)
+    (users/soft-delete-user! ds id)
 
     ; TODO: service needed
     (->> (jobs/prepare-congest-metadata
@@ -87,6 +87,6 @@
   [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
-    (users/cancel-soft-user-deletion! ds (keyword type) id)
+    (users/cancel-soft-user-deletion! ds id)
     (congest/deregister! js job-id)
     (res/response {:message "successfully cancelled user deletion"})))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -58,6 +58,7 @@
   [{:keys [ds js user] :as _request}]
   (let [{:keys [id type]} user
         job-id (handlers/user-deletion-job-id type id)]
+    ; TODO: service needed
     (->> (jobs/prepare-congest-metadata
           ds
           js

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -62,10 +62,10 @@
           ds
           js
           {:id job-id
-           :initial-delay (* 1000 60) #_(* 1000 60 60 24 30)
+           :initial-delay (* 1000 60 60 24 30)
            :auto-start true
            :stop-after-fail false,
-           :interval (* 1000 60) #_(* 1000 60 60 24 30)
+           :interval (* 1000 60 60 24 30)
            :recurring? false
            :kill-after 1
            :args {:user-type type

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -98,7 +98,9 @@
              :openapi {:security [{:bearerAuth []}]}}
 
       ["" (-> (get me/get)
-              (post me/post))]
+              (post me/post)
+              (delete me/delete-user))]
+      ["/deletion/cancel" (get me/cancel-deletion)]
       ["/business" (-> (get me-business/get)
                        (post me-business/post))]
       ["/sectors" (-> (get me-sectors/get)

--- a/src/source/services/analytics/core.clj
+++ b/src/source/services/analytics/core.clj
@@ -169,7 +169,7 @@
                                             category-ids)))
                               (flatten)
                               (vec))]
-    (insert-event-categories! ds {:data event-categories})))
+    (when (seq event-categories) (insert-event-categories! ds {:data event-categories}))))
 
 (defn insert-post-event-categories!
   "Given a list of events and a list of posts (or a single event/post),

--- a/src/source/workers/feeds.clj
+++ b/src/source/workers/feeds.clj
@@ -1,14 +1,12 @@
 (ns source.workers.feeds
   (:require [source.util :as utils]
             [source.services.xml-schemas :as xml]
-            [source.jobs.core :as jobs]
             [congest.jobs :as congest]
-            [source.db.honey :as hon]
-            [source.jobs.handlers :as handlers]))
+            [source.db.honey :as hon]))
 
 (defn create-feed!
   "Creates feed with incoming posts pulled from RSS feed and starts associated job"
-  [ds js store {:keys [user-id feed-metadata]}]
+  [ds store {:keys [user-id feed-metadata]}]
   (let [{:keys [provider-id rss-url content-type-id]} feed-metadata
         datetime (utils/get-utc-timestamp-string)
         selection-schemas (->> [:= :provider-id provider-id]
@@ -36,33 +34,11 @@
                                        :creator-id user-id
                                        :content-type-id content-type-id
                                        :thumbnail (or (:thumbnail post) (:display-picture new-feed))}))
-                             extracted-posts)
-        {:keys [email]} (hon/find-one ds {:tname :users
-                                          :where [:= :id user-id]})]
-
+                             extracted-posts)]
     (if (some? extracted-posts)
       (do
         (hon/insert! ds {:tname :incoming-posts
                          :data extended-posts})
-
-        (->> (jobs/prepare-congest-metadata
-              ds
-              store
-              {:id (str email "-" (:id new-feed))
-               :initial-delay (* 1000 60 60 24)
-               :auto-start true
-               :stop-after-fail false,
-               :interval (* 1000 60 60 24)
-               :recurring? true
-               :args {:feed-id (:id new-feed)
-                      :creator-id user-id
-                      :content-type-id content-type-id
-                      :provider-id provider-id
-                      :url rss-url}
-               :handler :update-feed-posts
-               :created-at (utils/get-utc-timestamp-string)
-               :sleep false})
-             (congest/register! js))
         new-feed)
       false)))
 
@@ -72,9 +48,8 @@
                    :data feed-metadata
                    :ret :1}))
 
-(defn hard-delete-feed! [ds js creator-email feed-id]
-  (let [job-id (handlers/update-feed-posts-job-id creator-email feed-id)
-        post-ids (mapv :id (hon/find ds {:tname :incoming-posts
+(defn hard-delete-feed! [ds js job-id feed-id]
+  (let [post-ids (mapv :id (hon/find ds {:tname :incoming-posts
                                          :where [:= :feed-id feed-id]
                                          :ret :*}))]
     (hon/delete! ds {:tname :filtered-feeds

--- a/src/source/workers/integrations.clj
+++ b/src/source/workers/integrations.clj
@@ -4,14 +4,12 @@
             [source.db.util :as db.util]
             [source.services.bundle-categories :as bundle-categories]
             [source.services.bundle-content-types :as bundle-content-types]
-            [source.jobs.core :as jobs]
-            [source.jobs.handlers :as handlers]
             [source.util :as utils]
-            [congest.jobs :as congest]
             [source.db.tables :as tables]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [congest.jobs :as congest]))
 
-(defn create-integration! [ds js store {:keys [user-id bundle-metadata categories content-types]}]
+(defn create-integration! [ds {:keys [user-id bundle-metadata categories content-types]}]
   (let [new-bundle (bundles/create-bundle! ds {:user-id user-id
                                                :bundle-metadata bundle-metadata})]
     (migrate/migrate-bundle (:id new-bundle) ["up"])
@@ -20,72 +18,31 @@
       (bundle-categories/insert-bundle-categories! bundle-ds {:bundle-id (:id new-bundle)
                                                               :categories categories})
       (bundle-content-types/insert-bundle-content-types! ds {:bundle-id (:id new-bundle)
-                                                             :content-types content-types})
-
-      (let [categories-by-bundle (bundles/categories-in-bundle ds (:id new-bundle))]
-
-        ;TODO: service needed
-        (->> (jobs/prepare-congest-metadata
-              ds
-              store
-              {:id (handlers/update-bundle-job-id (:id new-bundle))
-               :initial-delay 0
-               :auto-start true
-               :stop-after-fail false,
-               :interval (* 1000 60 60 24)
-               :recurring? true
-               :ds ds
-               :args {:bundle-id (:id new-bundle)
-                      :categories categories-by-bundle}
-               :handler :update-bundle
-               :created-at (utils/get-utc-timestamp-string)
-               :sleep false})
-             (congest/register! js))))
+                                                             :content-types content-types}))
     new-bundle))
 
-(defn update-integration! [ds js store {:keys [bundle-id bundle-metadata categories content-types]}]
+(defn update-integration! [ds {:keys [bundle-id bundle-metadata categories content-types]}]
   (with-open [bundle-ds (db.util/conn :bundle bundle-id)]
     (bundles/update-bundle! ds {:id bundle-id
                                 :data bundle-metadata})
     (bundle-categories/update-bundle-categories! bundle-ds {:bundle-id bundle-id
                                                             :categories categories})
     (bundle-content-types/update-bundle-content-types! ds {:bundle-id bundle-id
-                                                           :content-types content-types})
-    (let [job-id (str "bundle_" bundle-id)
-          categories-by-bundle (bundles/categories-in-bundle ds bundle-id)]
-      ;TODO: service needed
-      (congest/deregister! js job-id)
-      (->> (jobs/prepare-congest-metadata
-            ds
-            store
-            {:id job-id
-             :initial-delay (* 1000 60 60 24)
-             :auto-start true
-             :stop-after-fail false,
-             :interval (* 1000 60 60 24)
-             :recurring? true
-             :ds ds
-             :args {:bundle-id bundle-id
-                    :categories categories-by-bundle}
-             :handler :update-bundle
-             :created-at (utils/get-utc-timestamp-string)
-             :sleep false})
-           (congest/register! js)))))
+                                                           :content-types content-types})))
 
-(defn hard-delete-bundle! [ds js bundle-id]
-  (let [job-id (handlers/update-bundle-job-id bundle-id)]
-    (hon/delete! ds {:tname :filtered-feeds
-                     :where [:= :bundle-id bundle-id]})
-    (hon/delete! ds {:tname :filtered-posts
-                     :where [:= :bundle-id bundle-id]})
-    (hon/delete! ds {:tname :bundle-content-types
-                     :where [:= :bundle-id bundle-id]})
-    (hon/delete! ds {:tname :events
-                     :where [:= :bundle-id bundle-id]})
-    (tables/drop-all-tables! (db.util/conn :bundle bundle-id))
-    (hon/delete! ds {:tname :bundles
-                     :where [:= :id bundle-id]})
-    (congest/deregister! js job-id)))
+(defn hard-delete-bundle! [ds js job-id bundle-id]
+  (hon/delete! ds {:tname :filtered-feeds
+                   :where [:= :bundle-id bundle-id]})
+  (hon/delete! ds {:tname :filtered-posts
+                   :where [:= :bundle-id bundle-id]})
+  (hon/delete! ds {:tname :bundle-content-types
+                   :where [:= :bundle-id bundle-id]})
+  (hon/delete! ds {:tname :events
+                   :where [:= :bundle-id bundle-id]})
+  (tables/drop-all-tables! (db.util/conn :bundle bundle-id))
+  (hon/delete! ds {:tname :bundles
+                   :where [:= :id bundle-id]})
+  (congest/deregister! js job-id))
 
 (defn generate-api-key! [ds user-id bundle-id]
   (let [uuid (utils/uuid)

--- a/src/source/workers/users.clj
+++ b/src/source/workers/users.clj
@@ -32,3 +32,21 @@
                                                :where [:= :id business-id]}))
     (hon/delete! ds {:tname :users
                      :where [:= :id user-id]})))
+
+(defn soft-delete-user! [ds user-type user-id]
+  (hon/update! ds {:tname :users
+                   :where [:= :id user-id]
+                   :data {:removed true}})
+  (when (= user-type :creator)
+    (hon/update! ds {:tname :incoming-posts
+                     :where [:= :creator-id user-id]
+                     :data {:redacted true}})))
+
+(defn cancel-soft-user-deletion! [ds user-type user-id]
+  (hon/update! ds {:tname :users
+                   :where [:= :id user-id]
+                   :data {:removed false}})
+  (when (= user-type :creator)
+    (hon/update! ds {:tname :incoming-posts
+                     :where [:= :creator-id user-id]
+                     :data {:redacted false}})))

--- a/src/source/workers/users.clj
+++ b/src/source/workers/users.clj
@@ -1,2 +1,34 @@
 (ns source.workers.users
-  (:require [source.workers.schemas :as schemas]))
+  (:require [source.workers.feeds :as feeds]
+            [source.workers.integrations :as integrations]
+            [source.db.honey :as hon]))
+
+(defn hard-delete-creator! [ds js user-id email]
+  (let [feed-ids (mapv :id (hon/find ds {:tname :feeds
+                                         :where [:= :user-id user-id]}))]
+    (run! #(feeds/hard-delete-feed! ds js (str email "-" %) %) feed-ids)
+    (hon/delete! ds {:tname :events
+                     :where [:= :creator-id user-id]})))
+
+(defn hard-delete-distributor! [ds js user-id]
+  (let [bundle-ids (mapv :id (hon/find ds {:tname :bundles
+                                           :where [:= :user-id user-id]}))]
+    (run! #(integrations/hard-delete-bundle! ds js (str "bundle_" %) %) bundle-ids)
+    (hon/delete! ds {:tname :events
+                     :where [:= :distributor-id user-id]})))
+
+(defn hard-delete-user! [ds js user-type user-id]
+  (let [{:keys [email business-id]} (hon/find-one ds {:tname :users
+                                                      :where [:= :id user-id]})]
+    (cond
+      (= user-type :creator)
+      (hard-delete-creator! ds js user-id email)
+      (= user-type :distributor)
+      (hard-delete-distributor! ds js user-id))
+
+    (hon/delete! ds {:tname :user-sectors
+                     :where [:= :user-id user-id]})
+    (when (some? business-id) (hon/delete! ds {:tname :businesses
+                                               :where [:= :id business-id]}))
+    (hon/delete! ds {:tname :users
+                     :where [:= :id user-id]})))

--- a/src/source/workers/users.clj
+++ b/src/source/workers/users.clj
@@ -33,20 +33,18 @@
     (hon/delete! ds {:tname :users
                      :where [:= :id user-id]})))
 
-(defn soft-delete-user! [ds user-type user-id]
+(defn soft-delete-user! [ds user-id]
   (hon/update! ds {:tname :users
                    :where [:= :id user-id]
-                   :data {:removed true}})
-  (when (= user-type :creator)
-    (hon/update! ds {:tname :incoming-posts
-                     :where [:= :creator-id user-id]
-                     :data {:redacted true}})))
+                   :data {:removed true}}))
 
-(defn cancel-soft-user-deletion! [ds user-type user-id]
+(defn cancel-soft-user-deletion! [ds user-id]
   (hon/update! ds {:tname :users
                    :where [:= :id user-id]
-                   :data {:removed false}})
-  (when (= user-type :creator)
-    (hon/update! ds {:tname :incoming-posts
-                     :where [:= :creator-id user-id]
-                     :data {:redacted false}})))
+                   :data {:removed false}}))
+
+(defn removed? [ds user-id]
+  (-> (hon/find ds {:tname :users
+                    :where [:= :id user-id]})
+      (:removed)
+      (= 0)))


### PR DESCRIPTION
- Added user deletion services
- Moved job registration from feed/integration services to handlers to prevent cyclic dependency when calling their deletion function from the user deletion job handler
- Added endpoint for scheduling user deletion job 30 days from schedule time
- Added endpoint for cancelling user deletion job
- Added soft user deletion by means of a removed field on the user
- Removed field checked by authz middlewares, fails if removed
- Removed field checked by feed-post-updating job, stops execution if removed
- Bundle job excludes posts from removed users