### PR TITLE
postgres table tenancy

### DIFF
--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -1,27 +1,26 @@
 (ns source.bundle-migrations.001-init-bundle-db
-  (:require [source.db.bundle]
-            [source.db.tables :as tables]
-            [next.jdbc :as jdbc]))
+  (:require [source.db.bundle :as bundle]
+            [source.db.tables :as tables]))
 
 (defn run-up! [context]
-  (let [ds-bundle (:db-bundle context)]
-    (try (jdbc/execute! ds-bundle ["CREATE DOMAIN DATETIME TEXT"]) (catch Exception _))
-
+  (let [{:keys [ds-master bundle-id]} context]
     (tables/create-tables!
-     ds-bundle
+     ds-master
      :source.db.bundle
-     [:outgoing-posts
-      :bundle-categories
-      :post-heuristics
-      :analytics
-      :event-categories])))
+     (-> [:outgoing-posts
+          :bundle-categories
+          :post-heuristics
+          :analytics
+          :event-categories]
+         (bundle/tnames bundle-id)))))
 
 (defn run-down! [context]
-  (let [ds-bundle (:db-bundle context)]
+  (let [{:keys [ds-master bundle-id]} context]
     (tables/drop-tables!
-     ds-bundle
-     [:outgoing-posts
-      :bundle-categories
-      :post-heuristics
-      :analytics
-      :event-categories])))
+     ds-master
+     (-> [:outgoing-posts
+          :bundle-categories
+          :post-heuristics
+          :analytics
+          :event-categories]
+         (bundle/tnames bundle-id)))))

--- a/src/source/bundle_migrations/002_outgoing_posts.clj
+++ b/src/source/bundle_migrations/002_outgoing_posts.clj
@@ -1,16 +1,18 @@
 (ns source.bundle-migrations.002-outgoing-posts
-  (:require [source.db.bundle]
+  (:require [source.db.bundle :as bundle]
             [source.db.tables :as tables]))
 
 (defn run-up! [context]
-  (let [ds-bundle (:db-bundle context)]
+  (let [{:keys [ds-master bundle-id]} context]
     (tables/create-tables!
-     ds-bundle
+     ds-master
      :source.db.bundle
-     [:outgoing-posts])))
+     (-> [:outgoing-posts]
+         (bundle/tnames bundle-id)))))
 
 (defn run-down! [context]
-  (let [ds-bundle (:db-bundle context)]
+  (let [{:keys [ds-master bundle-id]} context]
     (tables/drop-tables!
-     ds-bundle
-     [:outgoing-posts])))
+     ds-master
+     (-> [:outgoing-posts]
+         (bundle/tnames bundle-id)))))

--- a/src/source/db/bundle.clj
+++ b/src/source/db/bundle.clj
@@ -51,6 +51,13 @@
    [:event-type :text :not nil]
    [:timestamp :text :not nil]))
 
+(defn tname [tname id]
+  (-> (str (name tname) "-" id)
+      (keyword)))
+
+(defn tnames [tnames id]
+  (mapv #(tname % id) tnames))
+
 (comment
   (sql/format event-categories)
   (sql/format outgoing-posts)

--- a/src/source/migrate.clj
+++ b/src/source/migrate.clj
@@ -35,17 +35,18 @@
         datastore (store/create-datastore
                    {:ds db-migrate
                     :table-name "migrations"})]
+    (try (jdbc/execute! (:db-master context) ["CREATE DOMAIN DATETIME TEXT"]) (catch Exception _))
     (mallard/run {:context context
                   :store datastore
                   :operations migrations}
                  args)))
 
 (defn migrate-bundle [bundle-id args]
-  (let [db-name (db.util/db-name :bundle bundle-id)
-        context {:db-bundle (jdbc/get-datasource (-> {:dbname (db.util/db-name db-name)}
-                                                     (merge postgres-ds)))}
+  (let [context {:db-master (jdbc/get-datasource (-> {:dbname (db.util/db-name "master")}
+                                                     (merge postgres-ds)))
+                 :bundle-id bundle-id}
         datastore (store/create-datastore
-                   {:ds (:db-bundle context)
+                   {:ds (:db-master context)
                     :table-name "migrations"})]
     (mallard/run {:context context
                   :store datastore


### PR DESCRIPTION
Set up bundle migrations to create tenanted tables on master instead, added utility functions in bundle to construct tenanted table names.
