### PR TITLE
table tenancy refactor

### DIFF
--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -1,5 +1,5 @@
 (ns source.bundle-migrations.001-init-bundle-db
-  (:require [source.db.bundle :as bundle]
+  (:require [source.db.bundle]
             [source.db.tables :as tables]
             [source.db.util :as db.util]))
 

--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -3,15 +3,15 @@
             [source.db.tables :as tables]))
 
 (defn run-up! [context]
-  (let [{:keys [ds-master bundle-id]} context]
+  (let [{:keys [ds-master bundle-id]} context
+        tables [:outgoing-posts
+                :bundle-categories
+                :post-heuristics]]
     (tables/create-tables!
      ds-master
      :source.db.bundle
-     (-> [:outgoing-posts
-          :bundle-categories
-          :post-heuristics
-          :analytics
-          :event-categories]
+     tables
+     (-> tables
          (bundle/tnames bundle-id)))))
 
 (defn run-down! [context]
@@ -20,7 +20,5 @@
      ds-master
      (-> [:outgoing-posts
           :bundle-categories
-          :post-heuristics
-          :analytics
-          :event-categories]
+          :post-heuristics]
          (bundle/tnames bundle-id)))))

--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -7,12 +7,11 @@
         tables [:outgoing-posts
                 :bundle-categories
                 :post-heuristics]]
-    (tables/create-tables!
+    (tables/create-bundle-tables!
      ds-master
      :source.db.bundle
      tables
-     (-> tables
-         (bundle/tnames bundle-id)))))
+     bundle-id)))
 
 (defn run-down! [context]
   (let [{:keys [ds-master bundle-id]} context]

--- a/src/source/bundle_migrations/001_init_bundle_db.clj
+++ b/src/source/bundle_migrations/001_init_bundle_db.clj
@@ -1,6 +1,7 @@
 (ns source.bundle-migrations.001-init-bundle-db
   (:require [source.db.bundle :as bundle]
-            [source.db.tables :as tables]))
+            [source.db.tables :as tables]
+            [source.db.util :as db.util]))
 
 (defn run-up! [context]
   (let [{:keys [ds-master bundle-id]} context
@@ -20,4 +21,4 @@
      (-> [:outgoing-posts
           :bundle-categories
           :post-heuristics]
-         (bundle/tnames bundle-id)))))
+         (db.util/tnames bundle-id)))))

--- a/src/source/bundle_migrations/002_outgoing_posts.clj
+++ b/src/source/bundle_migrations/002_outgoing_posts.clj
@@ -3,11 +3,13 @@
             [source.db.tables :as tables]))
 
 (defn run-up! [context]
-  (let [{:keys [ds-master bundle-id]} context]
+  (let [{:keys [ds-master bundle-id]} context
+        tables [:outgoing-posts]]
     (tables/create-tables!
      ds-master
      :source.db.bundle
-     (-> [:outgoing-posts]
+     tables
+     (-> tables
          (bundle/tnames bundle-id)))))
 
 (defn run-down! [context]

--- a/src/source/bundle_migrations/002_outgoing_posts.clj
+++ b/src/source/bundle_migrations/002_outgoing_posts.clj
@@ -1,20 +1,20 @@
 (ns source.bundle-migrations.002-outgoing-posts
-  (:require [source.db.bundle :as bundle]
-            [source.db.tables :as tables]))
+  (:require [source.db.bundle]
+            [source.db.tables :as tables]
+            [source.db.util :as db.util]))
 
 (defn run-up! [context]
   (let [{:keys [ds-master bundle-id]} context
         tables [:outgoing-posts]]
-    (tables/create-tables!
+    (tables/create-bundle-tables!
      ds-master
      :source.db.bundle
      tables
-     (-> tables
-         (bundle/tnames bundle-id)))))
+     bundle-id)))
 
 (defn run-down! [context]
   (let [{:keys [ds-master bundle-id]} context]
     (tables/drop-tables!
      ds-master
      (-> [:outgoing-posts]
-         (bundle/tnames bundle-id)))))
+         (db.util/tnames bundle-id)))))

--- a/src/source/db/bundle.clj
+++ b/src/source/db/bundle.clj
@@ -7,8 +7,7 @@
    :event-categories
    (tables/table-id)
    [:event-id :integer :not nil]
-   [:category-id :text :not nil]
-   (tables/foreign-key :event-id :analytics :id)))
+   [:category-id :text :not nil]))
 
 (def outgoing-posts
   (tables/create-table-sql

--- a/src/source/db/event.clj
+++ b/src/source/db/event.clj
@@ -4,11 +4,12 @@
             [source.db.util :as db.util]
             [source.util :as util]
             [source.db.honey :as db]
-            [source.db.bundle :as bundle]))
+            [source.db.bundle :as bundle]
+            [honey.sql.helpers :as hsql]))
 
 (defn get-post-categories [ds post-id bundle-id]
-  (let [feed-id (-> (db/find-one ds {:tname (bundle/tname :outgoing-posts bundle-id)
-                                     :where [:= :id post-id]})
+  (let [feed-id (-> (db/find-one ds (-> (db.util/tname :outgoing-posts bundle-id)
+                                        (hsql/where [:= :id post-id])))
                     (:feed-id))]
     (feed-categories/category-id ds {:feed-id feed-id})))
 
@@ -26,9 +27,9 @@
                                                            :timestamp timestamp}
                                                     :ret :*})
                        (first))]
-      (db/insert! ds {:tname (bundle/tname :event-categories bundle-id)
-                      :data {:event-id event-id
-                             :category-id (:category-id categories)}}))
+      (db/insert! ds (-> (db.util/tname :event-categories bundle-id)
+                         (assoc :data {:event-id event-id
+                                       :category-id (:category-id categories)}))))
     (let [event-id (-> (analytics/insert-event! creator-ds {:data {:post_id post-id
                                                                    :event_type type
                                                                    :timestamp timestamp}

--- a/src/source/db/event.clj
+++ b/src/source/db/event.clj
@@ -3,34 +3,32 @@
             [source.services.feed-categories :as feed-categories]
             [source.db.util :as db.util]
             [source.util :as util]
-            [source.db.honey :as db]))
+            [source.db.honey :as db]
+            [source.db.bundle :as bundle]))
 
-(defn get-post-categories [bundle-ds ds post-id]
-  (let [feed-id (-> (db/find-one bundle-ds {:tname :outgoing-posts
-                                            :where [:= :id post-id]})
+(defn get-post-categories [ds post-id bundle-id]
+  (let [feed-id (-> (db/find-one ds {:tname (bundle/tname :outgoing-posts bundle-id)
+                                     :where [:= :id post-id]})
                     (:feed-id))]
     (feed-categories/category-id ds {:feed-id feed-id})))
 
 (defn log! [{:keys [post-id bundle-id type]}]
   (let [ds (db.util/conn :master)
         timestamp (util/get-utc-timestamp-string)
-        bundle-ds (->> bundle-id
-                       (db.util/db-name :bundle)
-                       (db.util/conn))
         creator-ds (->> {:post-id post-id}
                         (db/find ds)
                         (:creator-id)
                         (db.util/db-name :creator)
                         (db.util/conn))
-        categories (get-post-categories bundle-ds ds post-id)]
-    (let [event-id (-> (analytics/insert-event! bundle-ds {:data {:post_id post-id
-                                                                  :event_type type
-                                                                  :timestamp timestamp}
-                                                           :ret :*})
+        categories (get-post-categories ds post-id bundle-id)]
+    (let [event-id (-> (analytics/insert-event! ds {:data {:post_id post-id
+                                                           :event_type type
+                                                           :timestamp timestamp}
+                                                    :ret :*})
                        (first))]
-      (db/insert! bundle-ds {:tname :event-categories
-                             :data {:event-id event-id
-                                    :category-id (:category-id categories)}}))
+      (db/insert! ds {:tname (bundle/tname :event-categories bundle-id)
+                      :data {:event-id event-id
+                             :category-id (:category-id categories)}}))
     (let [event-id (-> (analytics/insert-event! creator-ds {:data {:post_id post-id
                                                                    :event_type type
                                                                    :timestamp timestamp}

--- a/src/source/db/honey.clj
+++ b/src/source/db/honey.clj
@@ -99,10 +99,7 @@
 (comment
   (hsql/where :or [:= :id 1] [:= :id 2])
 
-  (def ds (db.util/conn :bundle 5))
-
-  (find ds {:tname :outgoing-posts
-            :ret :*})
+  (def ds (db.util/conn))
 
   (insert! ds {:tname :sectors
                :values {:name "something"}

--- a/src/source/db/tables.clj
+++ b/src/source/db/tables.clj
@@ -33,16 +33,21 @@
   resolvable keyword, resolves the symbol to retrieve defined
   sql create table honey statements, prepares jdbc statements from them,
   and executes with next.jdbc, returning the result of the execution."
-  [ds ns tname]
-  (->> (resolve-sql-def ns tname)
-       (hon/execute! ds)))
+  ([ds ns tname]
+   (create-table! ds ns tname tname))
+  ([ds ns tname new-tname]
+   (let [table-stmt (-> (resolve-sql-def ns tname)
+                        (assoc :create-table [new-tname :if-not-exists]))]
+     (hon/execute! ds table-stmt))))
 
 (defn create-tables!
   "Like create-table! but accepts a vector of keywords for table names
   and runs create-table with ns on every table name keyword in the vector."
-  [ds ns tables]
-  (mapv #(create-table! ds ns %)
-        tables))
+  ([ds ns tables]
+   (create-tables! ds ns tables tables))
+  ([ds ns tables new-tnames]
+   (mapv (fn [t nt]
+           (create-table! ds ns t nt)) tables new-tnames)))
 
 (defn tables
   "returns all current tables in a postgres datasource"

--- a/src/source/db/tables.clj
+++ b/src/source/db/tables.clj
@@ -32,22 +32,28 @@
   "Given keywords ns and table, parses the keywords into a
   resolvable keyword, resolves the symbol to retrieve defined
   sql create table honey statements, prepares jdbc statements from them,
-  and executes with next.jdbc, returning the result of the execution."
-  ([ds ns tname]
-   (create-table! ds ns tname tname))
-  ([ds ns tname new-tname]
-   (let [table-stmt (-> (resolve-sql-def ns tname)
-                        (assoc :create-table [new-tname :if-not-exists]))]
-     (hon/execute! ds table-stmt))))
+  and executes with next.jdbc, returning the result of the execution.
+  tname can either be a resolvable var keyword, or a vector containing
+  a resolvable var keyword and a table name to be assigned"
+  [ds ns tname]
+  (let [multi? (vector? tname)
+        tname' (if multi? (first tname) tname)
+        new-tname (if multi? (last tname) tname)
+        table-stmt (-> (resolve-sql-def ns tname')
+                       (assoc :create-table [new-tname :if-not-exists]))]
+    (hon/execute! ds table-stmt)))
 
 (defn create-tables!
   "Like create-table! but accepts a vector of keywords for table names
   and runs create-table with ns on every table name keyword in the vector."
-  ([ds ns tables]
-   (create-tables! ds ns tables tables))
-  ([ds ns tables new-tnames]
-   (mapv (fn [t nt]
-           (create-table! ds ns t nt)) tables new-tnames)))
+  [ds ns tables]
+  (mapv #(create-table! ds ns %) tables))
+
+(defn create-bundle-tables!
+  [ds ns tables bundle-id]
+  (->> (mapv (fn [t] [t (-> (db.util/tname t bundle-id)
+                            :tname)]) tables)
+       (mapv #(create-table! ds ns %))))
 
 (defn tables
   "returns all current tables in a postgres datasource"

--- a/src/source/db/util.clj
+++ b/src/source/db/util.clj
@@ -43,6 +43,18 @@
    (assert (or (= db-type :bundle) (= db-type :creator)))
    (-conn (db-name db-type id))))
 
+(defn tname
+  ([tname id]
+   {:tname (->> (str (name tname) "-" id)
+                (keyword))})
+  ([data-map tname id]
+   (->> (str (name tname) "-" id)
+        (keyword)
+        (assoc data-map :tname))))
+
+(defn tnames [tnames id]
+  (mapv #(tname % id) tnames))
+
 (comment
   (def ds (conn :bundle 1))
   (jdbc/execute! ds ["DELETE FROM providers;"])

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -137,9 +137,9 @@
                                        acc))
                                    [] posts-in)]
         (when (seq posts-in)
-          (hon/delete! ds {:tname (bundle/tname :outgoing-posts bundle-id)})
-          (hon/insert! ds {:tname (bundle/tname :outgoing-posts bundle-id)
-                           :data outgoing-posts}))))))
+          (hon/delete! ds (db.util/tname :outgoing-posts bundle-id))
+          (hon/insert! ds (-> (db.util/tname :outgoing-posts bundle-id)
+                              (assoc :data outgoing-posts))))))))
 
 (defn user-deletion-job-id
   "returns the job id of a user deletion job with the given user id"

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -6,7 +6,8 @@
             [source.db.util :as db.util]
             [clojure.set :as set]
             [clojure.string :as string]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.db.bundle :as bundle]))
 
 (defmulti handler
   (fn [opts]
@@ -86,7 +87,6 @@
 (defmethod handler :update-bundle [_]
   (fn [{:keys [args ds]}]
     (let [{:keys [bundle-id categories]} args
-          ds-bundle (db.util/conn :bundle bundle-id)
           incoming-posts (services/incoming-posts-with-feeds ds {:where [:= :feeds.state "live"]})
           posts-categories (incoming-posts/categories-by-posts ds {:where [:= :state "live"]})]
       (run!
@@ -105,15 +105,17 @@
                matches (count (set/intersection (set post-categories-vec)
                                                 (set match-categories-vec)))]
             ; use matches as a score and upsert long-heuristic for this post
-           (services/upsert-post-heuristics! ds-bundle {:data [{:post-id (:id post)
-                                                                :long-heuristic matches}]})))
+           (services/upsert-post-heuristics! ds {:bundle-id bundle-id
+                                                 :data [{:post-id (:id post)
+                                                         :long-heuristic matches}]})))
        incoming-posts)
 
       ; pull highest scored posts by long heuristics into outgoing posts
             ; top 1000 post-heuristics records ordered by long heuristic in descending order
-      (let [top-by-long-heuristics (services/top-posts-by-heuristic ds-bundle
+      (let [top-by-long-heuristics (services/top-posts-by-heuristic ds
                                                                     {:heuristic :long-heuristic
-                                                                     :limit 1000})
+                                                                     :limit 1000
+                                                                     :bundle-id bundle-id})
             ; convert into a vector of id numbers
             ids (mapv :post-id top-by-long-heuristics)
 
@@ -135,9 +137,9 @@
                                        acc))
                                    [] posts-in)]
         (when (seq posts-in)
-          (hon/delete! ds-bundle {:tname :outgoing-posts})
-          (hon/insert! ds-bundle {:tname :outgoing-posts
-                                  :data outgoing-posts}))))))
+          (hon/delete! ds {:tname (bundle/tname :outgoing-posts bundle-id)})
+          (hon/insert! ds {:tname (bundle/tname :outgoing-posts bundle-id)
+                           :data outgoing-posts}))))))
 
 (defn user-deletion-job-id
   "returns the job id of a user deletion job with the given user id"

--- a/src/source/migrate.clj
+++ b/src/source/migrate.clj
@@ -42,12 +42,12 @@
                  args)))
 
 (defn migrate-bundle [bundle-id args]
-  (let [context {:db-master (jdbc/get-datasource (-> {:dbname (db.util/db-name "master")}
+  (let [context {:ds-master (jdbc/get-datasource (-> {:dbname (db.util/db-name "master")}
                                                      (merge postgres-ds)))
                  :bundle-id bundle-id}
         datastore (store/create-datastore
-                   {:ds (:db-master context)
-                    :table-name "migrations"})]
+                   {:ds (:ds-master context)
+                    :table-name (str "migrations_" bundle-id)})]
     (mallard/run {:context context
                   :store datastore
                   :operations bundle-migrations}

--- a/src/source/routes/bundle_post.clj
+++ b/src/source/routes/bundle_post.clj
@@ -1,8 +1,8 @@
 (ns source.routes.bundle-post
-  (:require [source.db.util :as db.util]
-            [ring.util.response :as res]
+  (:require [ring.util.response :as res]
             [source.services.analytics.interface :as analytics]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.db.bundle :as bundle]))
 
 (defn get
   {:summary "get a single outgoing post in the uuid-authorized bundle by post id, updates click analytics"
@@ -27,9 +27,7 @@
                404 {:body [:map [:message :string]]}}}
 
   [{:keys [ds bundle-id path-params] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        post (hon/find-one bundle-ds {:tname :outgoing-posts
-                                      :where [:= :id (:id path-params)]
-                                      :ret :1})]
+  (let [post (hon/find-one ds {:tname (bundle/tname :outgoing-posts bundle-id)
+                               :where [:= :id (:id path-params)]})]
     (analytics/insert-post-click! ds post bundle-id)
     (res/response post)))

--- a/src/source/routes/bundle_post.clj
+++ b/src/source/routes/bundle_post.clj
@@ -2,7 +2,9 @@
   (:require [ring.util.response :as res]
             [source.services.analytics.interface :as analytics]
             [source.db.honey :as hon]
-            [source.db.bundle :as bundle]))
+            [source.db.bundle :as bundle]
+            [source.db.util :as db.util]
+            [honey.sql.helpers :as hsql]))
 
 (defn get
   {:summary "get a single outgoing post in the uuid-authorized bundle by post id, updates click analytics"
@@ -27,7 +29,7 @@
                404 {:body [:map [:message :string]]}}}
 
   [{:keys [ds bundle-id path-params] :as _request}]
-  (let [post (hon/find-one ds {:tname (bundle/tname :outgoing-posts bundle-id)
-                               :where [:= :id (:id path-params)]})]
+  (let [post (hon/find-one ds (-> (db.util/tname :outgoing-posts bundle-id)
+                                  (hsql/where [:= :id (:id path-params)])))]
     (analytics/insert-post-click! ds post bundle-id)
     (res/response post)))

--- a/src/source/routes/integration_categories.clj
+++ b/src/source/routes/integration_categories.clj
@@ -1,7 +1,5 @@
 (ns source.routes.integration-categories
-  (:require [source.services.interface :as services]
-            [ring.util.response :as res]
-            [source.db.util :as db.util]
+  (:require [ring.util.response :as res]
             [source.services.bundles :as bundles]
             [source.services.bundle-categories :as bundle-categories]))
 
@@ -27,8 +25,7 @@
                         [:name :string]]]}
    :responses {200 {:body [:map [:message :string]]}}}
 
-  [{:keys [path-params body] :as _request}]
-  (let [bundle-ds (db.util/conn :bundle (:id path-params))]
-    (bundle-categories/update-bundle-categories! bundle-ds {:bundle-id (:id path-params)
-                                                            :categories body})
-    (res/response {:message "successfully updated integration categories"})))
+  [{:keys [ds path-params body] :as _request}]
+  (bundle-categories/update-bundle-categories! ds {:bundle-id (:id path-params)
+                                                   :categories body})
+  (res/response {:message "successfully updated integration categories"}))

--- a/src/source/services/bundle_categories.clj
+++ b/src/source/services/bundle_categories.clj
@@ -1,19 +1,6 @@
 (ns source.services.bundle-categories
-  (:require [source.db.interface :as db]))
-
-(defn insert-bundle-category! [ds {:keys [_data _ret] :as opts}]
-  (->> {:tname :bundle-categories}
-       (merge opts)
-       (db/insert! ds)))
-
-(defn delete-bundle-category! [ds {:keys [id where] :as opts}]
-  (->> {:tname :bundle-categories
-        :where (if (some? id)
-                 [:= :id id]
-                 where)
-        :ret :1}
-       (merge opts)
-       (db/delete! ds)))
+  (:require [source.db.interface :as db]
+            [source.db.bundle :as bundle]))
 
 (defn category-id [ds {:keys [bundle-id where] :as opts}]
   (->> {:tname :bundle-categories
@@ -28,11 +15,14 @@
   (let [bundle-categories (mapv (fn [{:keys [id]}]
                                   {:bundle-id bundle-id
                                    :category-id id}) categories)]
-    (insert-bundle-category! ds {:data bundle-categories})))
+    (db/insert! ds {:tname (bundle/tname :bundle-categories bundle-id)
+                    :data bundle-categories})))
 
 (defn update-bundle-categories! [ds {:keys [bundle-id categories]}]
   (let [bundle-categories (mapv (fn [{:keys [id]}]
                                   {:bundle-id bundle-id
                                    :category-id id}) categories)]
-    (delete-bundle-category! ds {:where [:= :bundle-id bundle-id]})
-    (insert-bundle-category! ds {:data bundle-categories})))
+    (db/delete! ds {:tname (bundle/tname :bundle-categories bundle-id)
+                    :where [:= :bundle-id bundle-id]})
+    (db/insert! ds {:tname (bundle/tname :bundle-categories bundle-id)
+                    :data bundle-categories})))

--- a/src/source/services/bundle_categories.clj
+++ b/src/source/services/bundle_categories.clj
@@ -1,6 +1,7 @@
 (ns source.services.bundle-categories
   (:require [source.db.interface :as db]
-            [source.db.bundle :as bundle]))
+            [source.db.bundle :as bundle]
+            [source.db.util :as db.util]))
 
 (defn category-id [ds {:keys [bundle-id where] :as opts}]
   (->> {:tname :bundle-categories
@@ -15,14 +16,14 @@
   (let [bundle-categories (mapv (fn [{:keys [id]}]
                                   {:bundle-id bundle-id
                                    :category-id id}) categories)]
-    (db/insert! ds {:tname (bundle/tname :bundle-categories bundle-id)
-                    :data bundle-categories})))
+    (db/insert! ds (-> (db.util/tname :bundle-categories bundle-id)
+                       (assoc :data bundle-categories)))))
 
 (defn update-bundle-categories! [ds {:keys [bundle-id categories]}]
   (let [bundle-categories (mapv (fn [{:keys [id]}]
                                   {:bundle-id bundle-id
                                    :category-id id}) categories)]
-    (db/delete! ds {:tname (bundle/tname :bundle-categories bundle-id)
+    (db/delete! ds {:tname (db.util/tname :bundle-categories bundle-id)
                     :where [:= :bundle-id bundle-id]})
-    (db/insert! ds {:tname (bundle/tname :bundle-categories bundle-id)
-                    :data bundle-categories})))
+    (db/insert! ds (-> (db.util/tname :bundle-categories bundle-id)
+                       (assoc :data bundle-categories)))))

--- a/src/source/services/bundles.clj
+++ b/src/source/services/bundles.clj
@@ -1,7 +1,8 @@
 (ns source.services.bundles
   (:require [source.db.interface :as db]
             [source.util :as utils]
-            [source.db.bundle :as bundle]))
+            [source.db.util :as db.util]
+            [honey.sql.helpers :as hsql]))
 
 (defn insert-bundle! [ds {:keys [_values _ret] :as opts}]
   (->> {:tname :bundles}
@@ -44,8 +45,8 @@
 
 ;;NEW
 (defn categories-in-bundle [ds bundle-id]
-  (let [category-ids (db/find-one ds {:tname (bundle/tname :bundle-categories bundle-id)
-                                      :where [:= :bundle-id bundle-id]})
+  (let [category-ids (db/find-one ds (-> (db.util/tname :bundle-categories bundle-id)
+                                         (hsql/where [:= :bundle-id bundle-id])))
         id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)]
     (db/find ds {:tname :categories
                  :where [:in :id id-vec]})))

--- a/src/source/services/bundles.clj
+++ b/src/source/services/bundles.clj
@@ -1,9 +1,7 @@
 (ns source.services.bundles
   (:require [source.db.interface :as db]
             [source.util :as utils]
-            [source.services.bundle-categories :as bundle-categories]
-            [source.db.util :as db.util]
-            [source.db.honey :as hon]))
+            [source.db.bundle :as bundle]))
 
 (defn insert-bundle! [ds {:keys [_values _ret] :as opts}]
   (->> {:tname :bundles}
@@ -46,8 +44,8 @@
 
 ;;NEW
 (defn categories-in-bundle [ds bundle-id]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        category-ids (bundle-categories/category-id bundle-ds {:bundle-id bundle-id})
+  (let [category-ids (db/find-one ds {:tname (bundle/tname :bundle-categories bundle-id)
+                                      :where [:= :bundle-id bundle-id]})
         id-vec (mapv (fn [{:keys [category-id]}] category-id) category-ids)]
-    (hon/find ds {:tname :categories
-                  :where [:in :id id-vec]})))
+    (db/find ds {:tname :categories
+                 :where [:in :id id-vec]})))

--- a/src/source/services/post_heuristics.clj
+++ b/src/source/services/post_heuristics.clj
@@ -1,12 +1,12 @@
 (ns source.services.post-heuristics
   (:require [source.db.honey :as hon]
             [honey.sql.helpers :as hsql]
-            [source.db.bundle :as bundle]))
+            [source.db.util :as db.util]))
 
 (defn upsert-post-heuristics! [ds {:keys [bundle-id data]}]
   (hon/execute!
    ds
-   (-> (hsql/insert-into (bundle/tname :post-heuristics bundle-id))
+   (-> (hsql/insert-into (:tname (db.util/tname :post-heuristics bundle-id)))
        (hsql/values data)
        (assoc :on-conflict [:post-id])
        (assoc :do-update-set {:long-heuristic :excluded.long-heuristic
@@ -15,7 +15,7 @@
 (defn top-posts-by-heuristic [ds {:keys [select limit heuristic bundle-id] :as _opts}]
   (hon/execute! ds
                 (merge {:select (or select :*)
-                        :from (bundle/tname :post-heuristics bundle-id)
+                        :from (:tname (db.util/tname :post-heuristics bundle-id))
                         :order-by [[heuristic :desc]]
                         :limit limit})
                 {:ret :*}))

--- a/src/source/services/post_heuristics.clj
+++ b/src/source/services/post_heuristics.clj
@@ -1,21 +1,21 @@
 (ns source.services.post-heuristics
-  (:require [source.db.interface :as db]
-            [source.db.honey :as hon]
-            [honey.sql.helpers :as hsql]))
+  (:require [source.db.honey :as hon]
+            [honey.sql.helpers :as hsql]
+            [source.db.bundle :as bundle]))
 
-(defn upsert-post-heuristics! [ds {:keys [data]}]
+(defn upsert-post-heuristics! [ds {:keys [bundle-id data]}]
   (hon/execute!
    ds
-   (-> (hsql/insert-into :post-heuristics)
+   (-> (hsql/insert-into (bundle/tname :post-heuristics bundle-id))
        (hsql/values data)
        (assoc :on-conflict [:post-id])
        (assoc :do-update-set {:long-heuristic :excluded.long-heuristic
                               :short-heuristic :excluded.short-heuristic}))))
 
-(defn top-posts-by-heuristic [ds {:keys [select limit heuristic] :as _opts}]
+(defn top-posts-by-heuristic [ds {:keys [select limit heuristic bundle-id] :as _opts}]
   (hon/execute! ds
                 (merge {:select (or select :*)
-                        :from :post-heuristics
+                        :from (bundle/tname :post-heuristics bundle-id)
                         :order-by [[heuristic :desc]]
                         :limit limit})
                 {:ret :*}))

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -3,13 +3,13 @@
             [honey.sql.helpers :as hsql]
             [clojure.set :as set]
             [source.services.feed-categories :as feed-categories]
-            [source.db.bundle :as bundle]))
+            [source.db.bundle :as bundle]
+            [source.db.util :as db.util]))
 
 (defn get-bundle-categories
   "Get all categories for feeds/posts in bundle"
   [ds bundle-id]
-  (let [feed-ids (->> (hon/find ds {:tname (bundle/tname :outgoing-posts bundle-id)
-                                    :ret :*})
+  (let [feed-ids (->> (hon/find ds (db.util/tname :outgoing-posts bundle-id))
                       (mapv :feed-id))
         category-ids (->> (hon/find ds {:tname :feed-categories
                                         :where [:in :feed-id feed-ids]
@@ -22,8 +22,7 @@
 (defn get-outgoing-feeds
   "Gets a filtered list of outgoing feeds for the associated bundle."
   [ds {:keys [bundle-id type latest category-ids nonfiltered]}]
-  (let [feed-ids (mapv :feed-id (hon/find ds {:tname (bundle/tname :outgoing-posts bundle-id)
-                                              :ret :*}))
+  (let [feed-ids (mapv :feed-id (hon/find ds (db.util/tname :outgoing-posts bundle-id)))
         category-filtered-feed-ids (if (empty? category-ids)
                                      feed-ids
                                      (->> (hsql/where
@@ -65,8 +64,7 @@
                                                     (when (seq blocked-post-ids) [:not [:in :id blocked-post-ids]])
                                                     [:in :feed-id available-feed-ids])
                                         (assoc :order-by (when (= latest "true") [[[:posted-at :desc]]]))
-                                        (merge {:tname (bundle/tname :outgoing-posts bundle-id)
-                                                :ret :*})))
+                                        (merge (db.util/tname :outgoing-posts bundle-id))))
 
         categorised-posts (vec
                            (if (seq category-ids)

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -1,16 +1,15 @@
 (ns source.workers.bundles
-  (:require [source.db.util :as db.util]
-            [source.db.honey :as hon]
+  (:require [source.db.honey :as hon]
             [honey.sql.helpers :as hsql]
             [clojure.set :as set]
-            [source.services.feed-categories :as feed-categories]))
+            [source.services.feed-categories :as feed-categories]
+            [source.db.bundle :as bundle]))
 
 (defn get-bundle-categories
   "Get all categories for feeds/posts in bundle"
   [ds bundle-id]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        feed-ids (->> (hon/find bundle-ds {:tname :outgoing-posts
-                                           :ret :*})
+  (let [feed-ids (->> (hon/find ds {:tname (bundle/tname :outgoing-posts bundle-id)
+                                    :ret :*})
                       (mapv :feed-id))
         category-ids (->> (hon/find ds {:tname :feed-categories
                                         :where [:in :feed-id feed-ids]
@@ -23,9 +22,8 @@
 (defn get-outgoing-feeds
   "Gets a filtered list of outgoing feeds for the associated bundle."
   [ds {:keys [bundle-id type latest category-ids nonfiltered]}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        feed-ids (mapv :feed-id (hon/find bundle-ds {:tname :outgoing-posts
-                                                     :ret :*}))
+  (let [feed-ids (mapv :feed-id (hon/find ds {:tname (bundle/tname :outgoing-posts bundle-id)
+                                              :ret :*}))
         category-filtered-feed-ids (if (empty? category-ids)
                                      feed-ids
                                      (->> (hsql/where
@@ -41,7 +39,7 @@
                                                         :where [:= :bundle-id bundle-id]
                                                         :ret :*})))
         query (-> (hsql/where (when type [:= :content-type-id type])
-                              [:in :id category-filtered-feed-ids]
+                              (when (seq category-filtered-feed-ids) [:in :id category-filtered-feed-ids])
                               (when (seq blocked-feed-ids) [:not [:in :id blocked-feed-ids]]))
                   (assoc :order-by (when latest [[:created-at :desc]]))
                   (merge {:tname :feeds
@@ -52,8 +50,7 @@
 (defn get-outgoing-posts
   "Get outgoing posts based on short heuristics and update analytics impressions"
   [ds {:keys [bundle-id limit start type latest category-ids]}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)
-        all-feed-ids (mapv :id (hon/find ds {:tname :feeds
+  (let [all-feed-ids (mapv :id (hon/find ds {:tname :feeds
                                              :ret :*}))
         blocked-feed-ids (mapv :feed-id (hon/find ds {:tname :filtered-feeds
                                                       :where [:= :bundle-id bundle-id]
@@ -64,12 +61,12 @@
                                                       :where [:= :bundle-id bundle-id]
                                                       :ret :*}))
 
-        filtered-posts (hon/find bundle-ds (-> (hsql/where (when type [:= :content-type-id type])
-                                                           (when (seq blocked-post-ids) [:not [:in :id blocked-post-ids]])
-                                                           [:in :feed-id available-feed-ids])
-                                               (assoc :order-by (when (= latest "true") [[[:posted-at :desc]]]))
-                                               (merge {:tname :outgoing-posts
-                                                       :ret :*})))
+        filtered-posts (hon/find ds (-> (hsql/where (when type [:= :content-type-id type])
+                                                    (when (seq blocked-post-ids) [:not [:in :id blocked-post-ids]])
+                                                    [:in :feed-id available-feed-ids])
+                                        (assoc :order-by (when (= latest "true") [[[:posted-at :desc]]]))
+                                        (merge {:tname (bundle/tname :outgoing-posts bundle-id)
+                                                :ret :*})))
 
         categorised-posts (vec
                            (if (seq category-ids)

--- a/src/source/workers/integrations.clj
+++ b/src/source/workers/integrations.clj
@@ -7,30 +7,26 @@
             [source.util :as utils]
             [source.db.tables :as tables]
             [source.db.honey :as hon]
-            [congest.jobs :as congest]
-            [next.jdbc :as jdbc]))
+            [congest.jobs :as congest]))
 
 (defn create-integration! [ds {:keys [user-id bundle-metadata categories content-types]}]
   (let [new-bundle (bundles/create-bundle! ds {:user-id user-id
                                                :bundle-metadata bundle-metadata})]
-    (jdbc/execute! ds [(str "CREATE DATABASE bundle_" (:id new-bundle))])
     (migrate/migrate-bundle (:id new-bundle) ["up"])
 
-    (let [bundle-ds (db.util/conn :bundle (:id new-bundle))]
-      (bundle-categories/insert-bundle-categories! bundle-ds {:bundle-id (:id new-bundle)
-                                                              :categories categories})
-      (bundle-content-types/insert-bundle-content-types! ds {:bundle-id (:id new-bundle)
-                                                             :content-types content-types}))
+    (bundle-categories/insert-bundle-categories! ds {:bundle-id (:id new-bundle)
+                                                     :categories categories})
+    (bundle-content-types/insert-bundle-content-types! ds {:bundle-id (:id new-bundle)
+                                                           :content-types content-types})
     new-bundle))
 
 (defn update-integration! [ds {:keys [bundle-id bundle-metadata categories content-types]}]
-  (let [bundle-ds (db.util/conn :bundle bundle-id)]
-    (bundles/update-bundle! ds {:id bundle-id
-                                :data bundle-metadata})
-    (bundle-categories/update-bundle-categories! bundle-ds {:bundle-id bundle-id
-                                                            :categories categories})
-    (bundle-content-types/update-bundle-content-types! ds {:bundle-id bundle-id
-                                                           :content-types content-types})))
+  (bundles/update-bundle! ds {:id bundle-id
+                              :data bundle-metadata})
+  (bundle-categories/update-bundle-categories! ds {:bundle-id bundle-id
+                                                   :categories categories})
+  (bundle-content-types/update-bundle-content-types! ds {:bundle-id bundle-id
+                                                         :content-types content-types}))
 
 (defn hard-delete-bundle! [ds js job-id bundle-id]
   (hon/delete! ds {:tname :filtered-feeds

--- a/src/source/workers/integrations.clj
+++ b/src/source/workers/integrations.clj
@@ -7,7 +7,8 @@
             [source.util :as utils]
             [source.db.tables :as tables]
             [source.db.honey :as hon]
-            [congest.jobs :as congest]))
+            [congest.jobs :as congest]
+            [source.db.bundle :as bundle]))
 
 (defn create-integration! [ds {:keys [user-id bundle-metadata categories content-types]}]
   (let [new-bundle (bundles/create-bundle! ds {:user-id user-id
@@ -37,7 +38,10 @@
                    :where [:= :bundle-id bundle-id]})
   (hon/delete! ds {:tname :events
                    :where [:= :bundle-id bundle-id]})
-  (tables/drop-all-tables! (db.util/conn :bundle bundle-id))
+  (tables/drop-tables! ds (bundle/tnames [:outgoing-posts
+                                          :bundle-categories
+                                          :post-heuristics]
+                                         bundle-id))
   (hon/delete! ds {:tname :bundles
                    :where [:= :id bundle-id]})
   (congest/deregister! js job-id))

--- a/src/source/workers/integrations.clj
+++ b/src/source/workers/integrations.clj
@@ -38,10 +38,10 @@
                    :where [:= :bundle-id bundle-id]})
   (hon/delete! ds {:tname :events
                    :where [:= :bundle-id bundle-id]})
-  (tables/drop-tables! ds (bundle/tnames [:outgoing-posts
-                                          :bundle-categories
-                                          :post-heuristics]
-                                         bundle-id))
+  (tables/drop-tables! ds (db.util/tnames [:outgoing-posts
+                                           :bundle-categories
+                                           :post-heuristics]
+                                          bundle-id))
   (hon/delete! ds {:tname :bundles
                    :where [:= :id bundle-id]})
   (congest/deregister! js job-id))


### PR DESCRIPTION
- Refactored all instances of bundle-ds to use tables instead
- Fixed migrations to use a different migration table name for each bundle, ensured correct tables are created
