### PR TITLE
bundle categories filtering

### DIFF
--- a/Source.postman_collection.json
+++ b/Source.postman_collection.json
@@ -625,7 +625,7 @@
 			"response": []
 		},
 		{
-			"name": "Bundle Categories",
+			"name": "Bundle Exists",
 			"request": {
 				"auth": {
 					"type": "bearer",
@@ -655,6 +655,32 @@
 						{
 							"key": "uuid",
 							"value": "1c1953c7cbeeefd2"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Bundle Categories",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/bundle/categories?uuid=2bbeb46bbd70c82b",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"bundle",
+						"categories"
+					],
+					"query": [
+						{
+							"key": "uuid",
+							"value": "2bbeb46bbd70c82b"
 						}
 					]
 				}

--- a/src/source/routes/bundle.clj
+++ b/src/source/routes/bundle.clj
@@ -1,6 +1,9 @@
 (ns source.routes.bundle
   (:require [ring.util.response :as res]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.db.util :as db.util]
+            [honey.sql.helpers :as hsql]
+            [pg.core :as pg]))
 
 (defn get
   {:summary "Get metadata for the associated uuid-authorized bundle."
@@ -21,3 +24,20 @@
   [{:keys [ds bundle-id] :as _request}]
   (res/response (hon/find-one ds {:tname :bundles
                                   :where [:= :id bundle-id]})))
+
+(defn exists
+  {:summary "Check for the existence of a bundle with the bundle UUID provided"
+   :parameters {:query [:map [:uuid {:description "Bundle UUID"} :string]]}
+   :responses {200 {:body [:map [:exists :boolean]]}
+               404 {:body [:map [:message :string]]}}}
+  [{:keys [ds query-params] :as _request}]
+  (res/response
+   (-> ds
+       (pg/execute "SELECT EXISTS(SELECT 1 FROM bundles WHERE uuid = $1) AS exists" {:params [(:uuid query-params)]})
+       (first))))
+
+(comment
+  (time (exists {:ds (db.util/conn)
+                 :query-params {:uuid "2bbeb46bbd70c82b"}}))
+  ())
+

--- a/src/source/routes/bundle.clj
+++ b/src/source/routes/bundle.clj
@@ -1,7 +1,6 @@
 (ns source.routes.bundle
   (:require [ring.util.response :as res]
             [source.db.honey :as hon]
-            [source.db.util :as db.util]
             [pg.core :as pg]))
 
 (defn get
@@ -33,9 +32,4 @@
    (-> ds
        (pg/execute "SELECT EXISTS(SELECT 1 FROM bundles WHERE uuid = $1) AS exists" {:params [(:uuid query-params)]})
        (first))))
-
-(comment
-  (time (exists {:ds (db.util/conn)
-                 :query-params {:uuid "2bbeb46bbd70c82b"}}))
-  ())
 

--- a/src/source/routes/bundle.clj
+++ b/src/source/routes/bundle.clj
@@ -2,7 +2,6 @@
   (:require [ring.util.response :as res]
             [source.db.honey :as hon]
             [source.db.util :as db.util]
-            [honey.sql.helpers :as hsql]
             [pg.core :as pg]))
 
 (defn get
@@ -28,8 +27,7 @@
 (defn exists
   {:summary "Check for the existence of a bundle with the bundle UUID provided"
    :parameters {:query [:map [:uuid {:description "Bundle UUID"} :string]]}
-   :responses {200 {:body [:map [:exists :boolean]]}
-               404 {:body [:map [:message :string]]}}}
+   :responses {200 {:body [:map [:exists :boolean]]}}}
   [{:keys [ds query-params] :as _request}]
   (res/response
    (-> ds

--- a/src/source/routes/bundle_categories.clj
+++ b/src/source/routes/bundle_categories.clj
@@ -4,7 +4,10 @@
 
 (defn get
   {:summary "Get all categories for which content is present in the uuid-authorized bundle (RSS feeds / posts)."
-   :parameters {:query [:map [:uuid {:description "Bundle UUID"} :string]]}
+   :parameters {:query [:map
+                        [:uuid {:description "Bundle UUID"} :string]
+                        [:type {:optional true
+                                :description "Filters by content type ID"} :int]]}
    :responses {200 {:body [:vector
                            [:map
                             [:id :int]
@@ -12,5 +15,6 @@
                             [:display-picture {:optional true} [:maybe :string]]]]}
                404 {:body [:map [:message :string]]}}}
 
-  [{:keys [bundle-id ds] :as _request}]
-  (res/response (bundles/get-bundle-categories ds bundle-id)))
+  [{:keys [ds bundle-id query-params] :as _request}]
+  (res/response (bundles/get-bundle-categories ds {:bundle-id bundle-id
+                                                   :content-type-id (:type query-params)})))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -225,6 +225,7 @@
       ["/feeds/:id/posts/:post-id" (get bundle-feed-post/get)]
       ["/posts" (post bundle-posts/post)]
       ["/posts/:id" (get bundle-post/get)]]
+     ["/bundle/exists" (get bundle/exists)]
 
      ["/admin" {:middleware [[mw/apply-auth {:required-type :admin}]]
                 :tags #{"admin"}

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -8,16 +8,13 @@
 
 (defn get-bundle-categories
   "Get all categories for feeds/posts in bundle"
-  [ds bundle-id]
-  (let [feed-ids (->> (hon/find ds (db.util/tname :outgoing-posts bundle-id))
-                      (mapv :feed-id))
-        category-ids (->> (hon/find ds {:tname :feed-categories
-                                        :where (when (seq feed-ids) [:in :feed-id feed-ids])
-                                        :ret :*})
-                          (mapv :category-id))]
-    (hon/find ds {:tname :categories
-                  :where (when (seq category-ids) [:in :id category-ids])
-                  :ret :*})))
+  [ds {:keys [bundle-id content-type-id]}]
+  (->> (-> (hsql/select-distinct :c.*)
+           (hsql/from [:categories :c])
+           (hsql/join [:feed-categories :fc] [:= :c.id :fc.category-id])
+           (hsql/join [(:tname (db.util/tname :outgoing-posts bundle-id)) :p] [:= :fc.feed-id :p.feed-id])
+           (hsql/where (when content-type-id [:= :p.content-type-id content-type-id])))
+       (hon/execute! ds)))
 
 (defn get-outgoing-feeds
   "Gets a filtered list of outgoing feeds for the associated bundle."
@@ -86,5 +83,7 @@
   (time (get-outgoing-posts (db.util/conn) {:bundle-id 14
                                             :category-ids [50 52 54]
                                             :latest "false"}))
+
+  (time (get-bundle-categories (db.util/conn) {:bundle-id 14}))
 
   ())


### PR DESCRIPTION
- optimised bundle categories endpoint and allowed for content type filtering
- added bundle exists endpoint that skips bundle authorization and checks existance of bundle with uuid as efficiently as possible
- updated postman collection

#177 