### PR TITLE
fixed bundle category filtering

### DIFF
--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -13,7 +13,13 @@
            (hsql/from [:categories :c])
            (hsql/join [:feed-categories :fc] [:= :c.id :fc.category-id])
            (hsql/join [(:tname (db.util/tname :outgoing-posts bundle-id)) :p] [:= :fc.feed-id :p.feed-id])
-           (hsql/where (when content-type-id [:= :p.content-type-id content-type-id])))
+           (hsql/group-by :c.id :c.name :c.display-picture)
+           (hsql/where (when content-type-id [:= :p.content-type-id content-type-id]))
+           (hsql/having (when (nil? content-type-id)
+                          [:=
+                           [:count [:distinct :p.content-type-id]]
+                           (-> (hsql/select [[:count :id]])
+                               (hsql/from :content-types))])))
        (hon/execute! ds)))
 
 (defn get-outgoing-feeds


### PR DESCRIPTION
Updated bundle categories endpoint such that if no content type is specified to filter against, it will filter against an intersection of all content types.
