### PR TITLE
improved posts pagination

### DIFF
--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -34,14 +34,15 @@
 
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [{:keys [limit start type latest seed]} (walk/keywordize-keys query-params)
-        {:keys [data] :as posts} (->> {:bundle-id bundle-id
-                                       :limit limit
-                                       :start start
-                                       :type type
-                                       :latest latest
-                                       :seed seed
-                                       :category-ids (:category-ids body)}
-                                      (bundles/get-outgoing-posts ds))]
+        {:keys [data] :as posts} (bundles/get-outgoing-posts
+                                  ds
+                                  {:bundle-id bundle-id
+                                   :limit limit
+                                   :start start
+                                   :type type
+                                   :latest latest
+                                   :seed seed
+                                   :category-ids (:category-ids body)})]
     (try
       (analytics/insert-post-impressions! ds data bundle-id)
       (catch Exception e (println (.getMessage e))))

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -31,9 +31,9 @@
                         [:seed {:optional true} [:maybe :string]]]}
    :responses {200 {:body [:map
                            [:pagination [:map
-                                         (api/sometimes :page-size :int)
-                                         (api/sometimes :total-size :int)
-                                         (api/sometimes :current-index :int)
+                                         [:page-size :int]
+                                         [:total-size :int]
+                                         [:current-index :int]
                                          (api/sometimes :next-index :int)]]
                            [:data [:vector
                                    [:map
@@ -50,8 +50,7 @@
                                     [:season [:maybe :int]]
                                     [:episode [:maybe :int]]
                                     [:redacted {:optional true} [:maybe :int]]
-                                    [:posted-at [:maybe :string]]]]]]}
-               404 {:boy [:map [:message :string]]}}}
+                                    [:posted-at [:maybe :string]]]]]]}}}
 
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [{:keys [limit start type latest seed]} (walk/keywordize-keys query-params)

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -2,7 +2,8 @@
   (:require [clojure.walk :as walk]
             [ring.util.response :as res]
             [source.services.analytics.interface :as analytics]
-            [source.workers.bundles :as bundles]))
+            [source.workers.bundles :as bundles]
+            [source.routes.openapi :as api]))
 
 (defn post
   {:summary "Get a list of posts in the uuid-authorized bundle, determined by analytics.
@@ -29,10 +30,11 @@
                          [:enum "true" "false"]]
                         [:seed {:optional true} [:maybe :string]]]}
    :responses {200 {:body [:map
-                           [:page-size :int]
-                           [:total-size :int]
-                           [:current-index :int]
-                           [:next-index :int]
+                           [:pagination [:map
+                                         (api/sometimes :page-size :int)
+                                         (api/sometimes :total-size :int)
+                                         (api/sometimes :current-index :int)
+                                         (api/sometimes :next-index :int)]]
                            [:data [:vector
                                    [:map
                                     [:id :int]

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -28,35 +28,40 @@
                           :description "Filters by most recently uploaded posts, not determined by analytics"}
                          [:enum "true" "false"]]
                         [:seed {:optional true} [:maybe :string]]]}
-   :responses {200 {:body [:vector
-                           [:map
-                            [:id :int]
-                            [:post-id :string]
-                            [:feed-id :int]
-                            [:creator-id :int]
-                            [:content-type-id :int]
-                            [:title :string]
-                            [:thumbnail [:maybe :string]]
-                            [:info [:maybe :string]]
-                            [:url [:maybe :string]]
-                            [:stream-url [:maybe :string]]
-                            [:season [:maybe :int]]
-                            [:episode [:maybe :int]]
-                            [:redacted {:optional true} [:maybe :int]]
-                            [:posted-at [:maybe :string]]]]}
+   :responses {200 {:body [:map
+                           [:page-size :int]
+                           [:total-size :int]
+                           [:current-index :int]
+                           [:next-index :int]
+                           [:data [:vector
+                                   [:map
+                                    [:id :int]
+                                    [:post-id :string]
+                                    [:feed-id :int]
+                                    [:creator-id :int]
+                                    [:content-type-id :int]
+                                    [:title :string]
+                                    [:thumbnail [:maybe :string]]
+                                    [:info [:maybe :string]]
+                                    [:url [:maybe :string]]
+                                    [:stream-url [:maybe :string]]
+                                    [:season [:maybe :int]]
+                                    [:episode [:maybe :int]]
+                                    [:redacted {:optional true} [:maybe :int]]
+                                    [:posted-at [:maybe :string]]]]]]}
                404 {:boy [:map [:message :string]]}}}
 
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [{:keys [limit start type latest seed]} (walk/keywordize-keys query-params)
-        posts (->> {:bundle-id bundle-id
-                    :limit limit
-                    :start start
-                    :type type
-                    :latest latest
-                    :seed seed
-                    :category-ids (:category-ids body)}
-                   (bundles/get-outgoing-posts ds))]
+        {:keys [data] :as posts} (->> {:bundle-id bundle-id
+                                       :limit limit
+                                       :start start
+                                       :type type
+                                       :latest latest
+                                       :seed seed
+                                       :category-ids (:category-ids body)}
+                                      (bundles/get-outgoing-posts ds))]
     (try
-      (analytics/insert-post-impressions! ds posts bundle-id)
+      (analytics/insert-post-impressions! ds data bundle-id)
       (catch Exception e (println (.getMessage e))))
     (res/response posts)))

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -3,7 +3,8 @@
             [ring.util.response :as res]
             [source.services.analytics.interface :as analytics]
             [source.workers.bundles :as bundles]
-            [source.routes.openapi :as api]))
+            [source.routes.openapi :as api]
+            [source.workers.schemas :as schemas]))
 
 (defn post
   {:summary "Get a list of posts in the uuid-authorized bundle, determined by analytics.
@@ -29,28 +30,7 @@
                           :description "Filters by most recently uploaded posts, not determined by analytics"}
                          [:enum "true" "false"]]
                         [:seed {:optional true} [:maybe :string]]]}
-   :responses {200 {:body [:map
-                           [:pagination [:map
-                                         [:page-size :int]
-                                         [:total-size :int]
-                                         [:current-index :int]
-                                         (api/sometimes :next-index :int)]]
-                           [:data [:vector
-                                   [:map
-                                    [:id :int]
-                                    [:post-id :string]
-                                    [:feed-id :int]
-                                    [:creator-id :int]
-                                    [:content-type-id :int]
-                                    [:title :string]
-                                    [:thumbnail [:maybe :string]]
-                                    [:info [:maybe :string]]
-                                    [:url [:maybe :string]]
-                                    [:stream-url [:maybe :string]]
-                                    [:season [:maybe :int]]
-                                    [:episode [:maybe :int]]
-                                    [:redacted {:optional true} [:maybe :int]]
-                                    [:posted-at [:maybe :string]]]]]]}}}
+   :responses (api/success (schemas/paginated schemas/Posts))}
 
   [{:keys [ds bundle-id query-params body] :as _request}]
   (let [{:keys [limit start type latest seed]} (walk/keywordize-keys query-params)

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -81,10 +81,10 @@
 
         next-index (+ start limit)]
 
-    {:page-size (count limited-posts)
-     :total-size total-size
-     :current-index start
-     :next-index (when (< next-index total-size) next-index)
+    {:pagination {:page-size (count limited-posts)
+                  :total-size total-size
+                  :current-index start
+                  :next-index (when (< next-index total-size) next-index)}
      :data limited-posts}))
 
 (comment

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -67,7 +67,9 @@
                               (sort-by #(get order-map (first %)))
                               (mapv last)))
 
-        valid-start? (and (some? start) (>= start 0) (< start (count shuffled-posts)))
+        total-size (count shuffled-posts)
+
+        valid-start? (and (some? start) (>= start 0) (< start total-size))
         started-posts (if valid-start?
                         (subvec shuffled-posts start)
                         shuffled-posts)
@@ -75,8 +77,15 @@
         valid-limit? (and (some? limit) (> (count started-posts) limit))
         limited-posts (if valid-limit?
                         (subvec started-posts 0 limit)
-                        started-posts)]
-    limited-posts))
+                        started-posts)
+
+        next-index (+ start limit)]
+
+    {:page-size (count limited-posts)
+     :total-size total-size
+     :current-index start
+     :next-index (when (< next-index total-size) next-index)
+     :data limited-posts}))
 
 (comment
 

--- a/src/source/workers/schemas.clj
+++ b/src/source/workers/schemas.clj
@@ -1,5 +1,6 @@
 (ns source.workers.schemas
-  (:require [malli.util :as mu]))
+  (:require [malli.util :as mu]
+            [source.routes.openapi :as api]))
 
 (def Business
   [:map
@@ -109,6 +110,15 @@
       (mu/assoc :baseline Baseline)
       (mu/assoc :provider Provider)))
 
+(defn paginated [data-schema]
+  [:map
+   [:paginated [:map
+                [:page-size :int]
+                [:total-size :int]
+                [:current-index :int]
+                (api/sometimes :next-index :int)]]
+   [:data data-schema]])
+
 (def IncomingPostRecord
   [:map
    [:id :int]
@@ -141,6 +151,26 @@
    [:season :int]
    [:episode :int]
    [:posted-at :string]])
+
+(def Post
+  [:map
+   [:id :int]
+   [:post-id :string]
+   [:feed-id :int]
+   [:creator-id :int]
+   [:content-type-id :int]
+   [:title :string]
+   [:thumbnail (api/maybe :string)]
+   [:info (api/maybe :string)]
+   [:url (api/maybe :string)]
+   [:stream-url (api/maybe :string)]
+   [:season (api/maybe :int)]
+   [:episode (api/maybe :int)]
+   (api/sometimes :redacted :int)
+   [:posted-at (api/maybe :string)]])
+
+(def Posts
+  [:vector Post])
 
 (def JobStatus [:enum ["running" "stopped"]])
 


### PR DESCRIPTION
Improved pagination for the bundle posts endpoint such that it includes page-size, total-size, current-index, next-index and the data returned.
This is a breaking change for integrators of our API, we need to let them know as soon as this goes out.

#194 
