### PR TITLE
allow truncation

### DIFF
--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -7,34 +7,31 @@
             [source.workers.schemas :as schemas]
             [malli.util :as mu]))
 
+(def QueryTruncatePosts
+  [:truncate
+   {:optional true
+    :description "Truncates text in posts to a maximum of 100 characters. Defaults to true."}
+   [:enum "true" "false"]])
+
+(def QuerySeed
+  [:seed {:optional true} [:maybe :string]])
+
 (defn post
   {:summary "Get a list of posts in the uuid-authorized bundle, determined by analytics.
    This endpoint updates impression analytics for the returned posts."
    :description "This endpoint pulls a curated list of content (determined by analytics) of the posts that made it into the bundle during post selection. This can be filtered by content type ID, category IDs, or latest (most recently added posts). If results are filtered by latest, they will not be curated by analytics.
    
    Results can be paginated using the `start` and `limit` query parameters."
-   :parameters {:body [:map [:category-ids [:vector :int]]]
+   :parameters (api/params
+                :body [:map [:category-ids [:vector :int]]]
                 :query [:map
-                        [:uuid {:description "Bundle UUID"} :string]
-                        [:limit
-                         {:optional true
-                          :description "Used for pagination. Specifies a number of posts to be returned."}
-                         :int]
-                        [:start
-                         {:optional true
-                          :description "Used for pagination. Specifies the starting point for the returned posts, incremented by the limit."}
-                         :int]
-                        [:type {:optional true
-                                :description "Filters by content type ID"} :int]
-                        [:latest
-                         {:optional true
-                          :description "Filters by most recently uploaded posts, not determined by analytics"}
-                         [:enum "true" "false"]]
-                        [:truncate
-                         {:optional true
-                          :description "Truncates text in posts to a maximum of 100 characters. Defaults to true."}
-                         [:enum "true" "false"]]
-                        [:seed {:optional true} [:maybe :string]]]}
+                        schemas/QueryUUID
+                        schemas/QueryLimit
+                        schemas/QueryStart
+                        schemas/QueryContentType
+                        schemas/QueryLatest
+                        QueryTruncatePosts
+                        QuerySeed])
    :responses (api/success (api/paginated [:vector (-> schemas/Post
                                                        (mu/assoc :feed-title :string))]))}
 

--- a/src/source/routes/bundle_posts.clj
+++ b/src/source/routes/bundle_posts.clj
@@ -30,12 +30,16 @@
                          {:optional true
                           :description "Filters by most recently uploaded posts, not determined by analytics"}
                          [:enum "true" "false"]]
+                        [:truncate
+                         {:optional true
+                          :description "Truncates text in posts to a maximum of 100 characters. Defaults to true."}
+                         [:enum "true" "false"]]
                         [:seed {:optional true} [:maybe :string]]]}
    :responses (api/success (schemas/paginated [:vector (-> schemas/Post
                                                            (mu/assoc :feed-title :string))]))}
 
   [{:keys [ds bundle-id query-params body] :as _request}]
-  (let [{:keys [limit start type latest seed]} (walk/keywordize-keys query-params)
+  (let [{:keys [limit start type latest seed truncate]} (walk/keywordize-keys query-params)
         {:keys [data] :as posts} (bundles/get-outgoing-posts
                                   ds
                                   {:bundle-id bundle-id
@@ -44,6 +48,7 @@
                                    :type type
                                    :latest latest
                                    :seed seed
+                                   :truncate truncate
                                    :category-ids (:category-ids body)})]
     (try
       (analytics/insert-post-impressions! ds data bundle-id)

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -40,12 +40,29 @@
                                           filtered-query))]
     filtered-feeds))
 
+(defn- select-outgoing-post [truncate]
+  (hsql/select-distinct
+   :p.id
+   :p.post-id
+   :p.feed-id
+   :p.creator-id
+   :p.content-type-id
+   :p.title
+   :p.thumbnail
+   (if (= truncate "false") :p.info [[:left :p.info 100] :info])
+   :p.url
+   :p.stream-url
+   :p.season
+   :p.episode
+   :p.posted-at
+   [:f.title :feed-title]))
+
 (defn get-outgoing-posts
   "Get outgoing posts based on short heuristics and update analytics impressions"
-  [ds {:keys [bundle-id limit start type latest category-ids seed]}]
+  [ds {:keys [bundle-id limit start type latest category-ids seed truncate]}]
   (let [filtered-posts (hon/execute!
                         ds
-                        (-> (hsql/select-distinct :p.* [:f.title :feed-title])
+                        (-> (select-outgoing-post truncate)
                             (hsql/from [(:tname (db.util/tname :outgoing-posts bundle-id)) :p])
                             (hsql/join [:feeds :f] [:= :p.feed-id :f.id])
                             (hsql/join [:feed-categories :fc] [:= :p.feed-id :fc.feed-id])

--- a/src/source/workers/schemas.clj
+++ b/src/source/workers/schemas.clj
@@ -176,6 +176,31 @@
 (def Posts
   [:vector Post])
 
+(def QueryUUID
+  [:uuid {:description "Bundle UUID"} :string])
+
+(def QueryStart
+  [:start
+   {:optional true
+    :description "Used for pagination. Specifies the starting point for the returned items, incremented by the limit."}
+   :int])
+
+(def QueryLimit
+  [:limit
+   {:optional true
+    :description "Used for pagination. Specifies a number of items to be returned."}
+   :int])
+
+(def QueryContentType
+  [:type {:optional true
+          :description "Filters by content type ID"} :int])
+
+(def QueryLatest
+  [:latest
+   {:optional true
+    :description "Filters by most recently published"}
+   [:enum "true" "false"]])
+
 (def JobStatus [:enum ["running" "stopped"]])
 
 (def Job


### PR DESCRIPTION
Added a query parameter to truncate info on posts, this defaults to true for the bundle posts endpoint. Truncation is done in SQL and significantly improves request performance as the JSON size is significantly reduced.

This contributes to #179 