### PR TITLE
transactionalise database writes

### DIFF
--- a/src/source/routes/register.clj
+++ b/src/source/routes/register.clj
@@ -1,7 +1,6 @@
 (ns source.routes.register
   (:require [source.services.interface :as services]
             [ring.util.response :as res]
-            [source.util :as util]
             [source.db.honey :as hon]))
 
 (defn post

--- a/src/source/services/auth.clj
+++ b/src/source/services/auth.clj
@@ -1,7 +1,8 @@
 (ns source.services.auth
   (:require [source.password :as pw]
             [source.middleware.auth.core :as auth]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [pg.core :as pg]))
 
 (defn login [ds {:keys [user] :as _login}]
   (merge
@@ -9,15 +10,16 @@
    (auth/create-session (select-keys user [:id :type]))))
 
 (defn register [ds {:keys [email password] :as user}]
-  (hon/insert! ds {:tname :users
-                   :data (-> user
-                             (dissoc :confirm-password)
-                             (assoc :password (pw/hash-password password)))})
-  (let [user (hon/find-one ds {:tname :users
-                               :where [:= :email email]})]
-    (merge
-     {:user (dissoc user :password)}
-     (auth/create-session (select-keys user [:id :type])))))
+  (pg/with-transaction [ds ds]
+    (hon/insert! ds {:tname :users
+                     :data (-> user
+                               (dissoc :confirm-password)
+                               (assoc :password (pw/hash-password password)))})
+    (let [user (hon/find-one ds {:tname :users
+                                 :where [:= :email email]})]
+      (merge
+       {:user (dissoc user :password)}
+       (auth/create-session (select-keys user [:id :type]))))))
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/services/bundle_categories.clj
+++ b/src/source/services/bundle_categories.clj
@@ -2,7 +2,8 @@
   (:require [source.db.interface :as db]
             [source.db.bundle :as bundle]
             [source.db.util :as db.util]
-            [honey.sql.helpers :as hsql]))
+            [honey.sql.helpers :as hsql]
+            [pg.core :as pg]))
 
 (defn category-id [ds {:keys [bundle-id where] :as opts}]
   (->> {:tname :bundle-categories
@@ -21,10 +22,11 @@
                        (assoc :data bundle-categories)))))
 
 (defn update-bundle-categories! [ds {:keys [bundle-id categories]}]
-  (let [bundle-categories (mapv (fn [{:keys [id]}]
-                                  {:bundle-id bundle-id
-                                   :category-id id}) categories)]
-    (db/delete! ds (-> (db.util/tname :bundle-categories bundle-id)
-                       (hsql/where [:= :bundle-id bundle-id])))
-    (db/insert! ds (-> (db.util/tname :bundle-categories bundle-id)
-                       (assoc :data bundle-categories)))))
+  (pg/with-transaction [ds ds]
+    (let [bundle-categories (mapv (fn [{:keys [id]}]
+                                    {:bundle-id bundle-id
+                                     :category-id id}) categories)]
+      (db/delete! ds (-> (db.util/tname :bundle-categories bundle-id)
+                         (hsql/where [:= :bundle-id bundle-id])))
+      (db/insert! ds (-> (db.util/tname :bundle-categories bundle-id)
+                         (assoc :data bundle-categories))))))

--- a/src/source/services/bundle_content_types.clj
+++ b/src/source/services/bundle_content_types.clj
@@ -1,6 +1,7 @@
 (ns source.services.bundle-content-types
   (:require [source.db.interface :as db]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [pg.core :as pg]))
 
 ;;NEW
 (defn insert-bundle-content-types! [ds {:keys [bundle-id content-types]}]
@@ -33,9 +34,10 @@
 
 ;;NEW
 (defn update-bundle-content-types! [ds {:keys [bundle-id content-types]}]
-  (let [content-types (mapv (fn [{:keys [id]}]
-                              {:bundle-id bundle-id
-                               :content-type-id id}) content-types)]
-    (delete-bundle-content-types! ds {:where [:= :bundle-id bundle-id]})
-    (hon/insert! ds {:tname :bundle-content-types
-                     :data content-types})))
+  (pg/with-transaction [ds ds]
+    (let [content-types (mapv (fn [{:keys [id]}]
+                                {:bundle-id bundle-id
+                                 :content-type-id id}) content-types)]
+      (delete-bundle-content-types! ds {:where [:= :bundle-id bundle-id]})
+      (hon/insert! ds {:tname :bundle-content-types
+                       :data content-types}))))

--- a/src/source/services/user_sectors.clj
+++ b/src/source/services/user_sectors.clj
@@ -1,6 +1,7 @@
 (ns source.services.user-sectors
   (:require [source.db.interface :as db]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [pg.core :as pg]))
 
 (defn insert-user-sector! [ds {:keys [_data _ret] :as opts}]
   (->> {:tname :user-sectors}
@@ -28,8 +29,9 @@
 
 ;;NEW
 (defn update-user-sectors! [ds {:keys [user-id sectors]}]
-  (let [update-data (reduce (fn [acc {:keys [id]}]
-                              (conj acc {:user-id user-id
-                                         :sector-id id})) [] sectors)]
-    (delete-user-sector! ds {:where [:= :user-id user-id]})
-    (insert-user-sector! ds {:data update-data})))
+  (pg/with-transaction [ds ds]
+    (let [update-data (reduce (fn [acc {:keys [id]}]
+                                (conj acc {:user-id user-id
+                                           :sector-id id})) [] sectors)]
+      (delete-user-sector! ds {:where [:= :user-id user-id]})
+      (insert-user-sector! ds {:data update-data}))))

--- a/src/source/workers/feeds.clj
+++ b/src/source/workers/feeds.clj
@@ -19,7 +19,6 @@
                     (->> (yt/find-channel-id rss-url)
                          (str "https://www.youtube.com/feeds/videos.xml?channel_id="))
                     rss-url)
-
           selection-schemas (->> [:= :provider-id provider-id]
                                  (assoc {} :where)
                                  (xml/selection-schemas ds))

--- a/src/source/workers/feeds.clj
+++ b/src/source/workers/feeds.clj
@@ -4,57 +4,59 @@
             [congest.jobs :as congest]
             [source.db.honey :as hon]
             [source.rss.youtube :as yt]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [pg.core :as pg]))
 
 (defn create-feed!
   "Creates feed with incoming posts pulled from RSS feed and starts associated job"
   [ds {:keys [user-id feed-metadata]}]
-  (let [{:keys [provider-id rss-url content-type-id]} feed-metadata
-        datetime (utils/get-utc-timestamp-string)
-        youtube? (= provider-id 1)
-        rss-url (if (and youtube? (not (string/includes? rss-url "/feeds/videos.xml?channel_id=")))
-                  (->> (yt/find-channel-id rss-url)
-                       (str "https://www.youtube.com/feeds/videos.xml?channel_id="))
-                  rss-url)
+  (pg/with-transaction [ds ds]
+    (let [{:keys [provider-id rss-url content-type-id]} feed-metadata
+          datetime (utils/get-utc-timestamp-string)
+          youtube? (= provider-id 1)
+          rss-url (if (and youtube? (not (string/includes? rss-url "/feeds/videos.xml?channel_id=")))
+                    (->> (yt/find-channel-id rss-url)
+                         (str "https://www.youtube.com/feeds/videos.xml?channel_id="))
+                    rss-url)
 
-        selection-schemas (->> [:= :provider-id provider-id]
-                               (assoc {} :where)
-                               (xml/selection-schemas ds))
-        latest-ss (->> selection-schemas
-                       (reduce (fn [acc {:keys [id]}]
-                                 (conj acc id)) [])
-                       (apply max -1))
-        extracted (when-not (= latest-ss -1)
-                    (xml/extract-data ds latest-ss rss-url))
-        extracted-posts (get-in extracted [:feed :posts])
+          selection-schemas (->> [:= :provider-id provider-id]
+                                 (assoc {} :where)
+                                 (xml/selection-schemas ds))
+          latest-ss (->> selection-schemas
+                         (reduce (fn [acc {:keys [id]}]
+                                   (conj acc id)) [])
+                         (apply max -1))
+          extracted (when-not (= latest-ss -1)
+                      (xml/extract-data ds latest-ss rss-url))
+          extracted-posts (get-in extracted [:feed :posts])
 
-        display-picture (if youtube?
-                          (yt/channel-image (get-in extracted [:feed :url]))
-                          (get-in extracted [:feed :display-picture]))
+          display-picture (if youtube?
+                            (yt/channel-image (get-in extracted [:feed :url]))
+                            (get-in extracted [:feed :display-picture]))
 
-        new-feed (hon/insert!
-                  ds
-                  {:tname :feeds
-                   :data (merge feed-metadata {:title (get-in extracted [:feed :title])
-                                               :display-picture display-picture
-                                               :description (get-in extracted [:feed :description])
-                                               :user-id user-id
-                                               :created-at datetime
-                                               :state "pending"})
-                   :ret :1})
-        extended-posts (mapv (fn [post]
-                               (merge post
-                                      {:feed-id (:id new-feed)
-                                       :creator-id user-id
-                                       :content-type-id content-type-id
-                                       :thumbnail (or (:thumbnail post) (:display-picture new-feed))}))
-                             extracted-posts)]
-    (if (some? extracted-posts)
-      (do
-        (hon/insert! ds {:tname :incoming-posts
-                         :data extended-posts})
-        new-feed)
-      false)))
+          new-feed (hon/insert!
+                    ds
+                    {:tname :feeds
+                     :data (merge feed-metadata {:title (get-in extracted [:feed :title])
+                                                 :display-picture display-picture
+                                                 :description (get-in extracted [:feed :description])
+                                                 :user-id user-id
+                                                 :created-at datetime
+                                                 :state "pending"})
+                     :ret :1})
+          extended-posts (mapv (fn [post]
+                                 (merge post
+                                        {:feed-id (:id new-feed)
+                                         :creator-id user-id
+                                         :content-type-id content-type-id
+                                         :thumbnail (or (:thumbnail post) (:display-picture new-feed))}))
+                               extracted-posts)]
+      (if (some? extracted-posts)
+        (do
+          (hon/insert! ds {:tname :incoming-posts
+                           :data extended-posts})
+          new-feed)
+        false))))
 
 (defn update-feed! [ds {:keys [feed-id feed-metadata]}]
   (hon/update! ds {:tname :feeds
@@ -63,34 +65,36 @@
                    :ret :1}))
 
 (defn hard-delete-feed! [ds js job-id feed-id]
-  (let [post-ids (mapv :id (hon/find ds {:tname :incoming-posts
-                                         :where [:= :feed-id feed-id]}))
-        event-ids (:mapv :id (hon/find ds {:tname :events
-                                           :where [:= :feed-id feed-id]}))]
-    (hon/delete! ds {:tname :filtered-feeds
-                     :where [:= :feed-id feed-id]})
-    (hon/delete! ds {:tname :filtered-posts
-                     :where [:in :post-id post-ids]})
-    (hon/delete! ds {:tname :incoming-posts
-                     :where [:= :feed-id feed-id]})
-    (hon/delete! ds {:tname :feed-categories
-                     :where [:= :feed-id feed-id]})
-    (when (seq event-ids)
-      (hon/delete! ds {:tname :event-categories
-                       :where [:in :event-id event-ids]}))
-    (hon/delete! ds {:tname :events
-                     :where [:= :feed-id feed-id]})
-    (hon/delete! ds {:tname :feeds
-                     :where [:= :id feed-id]})
-    (congest/deregister! js job-id)))
+  (pg/with-transaction [ds ds]
+    (let [post-ids (mapv :id (hon/find ds {:tname :incoming-posts
+                                           :where [:= :feed-id feed-id]}))
+          event-ids (:mapv :id (hon/find ds {:tname :events
+                                             :where [:= :feed-id feed-id]}))]
+      (hon/delete! ds {:tname :filtered-feeds
+                       :where [:= :feed-id feed-id]})
+      (hon/delete! ds {:tname :filtered-posts
+                       :where [:in :post-id post-ids]})
+      (hon/delete! ds {:tname :incoming-posts
+                       :where [:= :feed-id feed-id]})
+      (hon/delete! ds {:tname :feed-categories
+                       :where [:= :feed-id feed-id]})
+      (when (seq event-ids)
+        (hon/delete! ds {:tname :event-categories
+                         :where [:in :event-id event-ids]}))
+      (hon/delete! ds {:tname :events
+                       :where [:= :feed-id feed-id]})
+      (hon/delete! ds {:tname :feeds
+                       :where [:= :id feed-id]})
+      (congest/deregister! js job-id))))
 
 (defn update-feed-categories! [ds {:keys [feed-id categories]}]
   (let [update-data (mapv (fn [{:keys [id]}]
                             {:feed-id feed-id
                              :category-id id}) categories)]
-    (when (seq update-data)
-      (hon/delete! ds {:tname :feed-categories
-                       :where [:= :feed-id feed-id]})
-      (hon/insert! ds {:tname :feed-categories
-                       :data update-data
-                       :ret :*}))))
+    (pg/with-transaction [ds ds]
+      (when (seq update-data)
+        (hon/delete! ds {:tname :feed-categories
+                         :where [:= :feed-id feed-id]})
+        (hon/insert! ds {:tname :feed-categories
+                         :data update-data
+                         :ret :*})))))

--- a/src/source/workers/integrations.clj
+++ b/src/source/workers/integrations.clj
@@ -6,60 +6,66 @@
             [source.services.bundle-content-types :as bundle-content-types]
             [source.db.tables :as tables]
             [source.db.honey :as hon]
-            [congest.jobs :as congest]))
+            [congest.jobs :as congest]
+            [pg.core :as pg]))
 
 (defn create-integration! [ds {:keys [user-id bundle-metadata categories content-types]}]
-  (let [new-bundle (bundles/create-bundle! ds {:user-id user-id
-                                               :bundle-metadata bundle-metadata})]
-    (migrate/migrate-bundle (:id new-bundle) ["up"])
+  (pg/with-transaction [ds ds]
+    (let [new-bundle (bundles/create-bundle! ds {:user-id user-id
+                                                 :bundle-metadata bundle-metadata})]
+      (migrate/migrate-bundle (:id new-bundle) ["up"])
 
-    (bundle-categories/insert-bundle-categories! ds {:bundle-id (:id new-bundle)
-                                                     :categories categories})
-    (bundle-content-types/insert-bundle-content-types! ds {:bundle-id (:id new-bundle)
-                                                           :content-types content-types})
-    new-bundle))
+      (bundle-categories/insert-bundle-categories! ds {:bundle-id (:id new-bundle)
+                                                       :categories categories})
+      (bundle-content-types/insert-bundle-content-types! ds {:bundle-id (:id new-bundle)
+                                                             :content-types content-types})
+      new-bundle)))
 
 (defn update-integration! [ds {:keys [bundle-id bundle-metadata categories content-types]}]
-  (bundles/update-bundle! ds {:id bundle-id
-                              :data bundle-metadata})
-  (bundle-categories/update-bundle-categories! ds {:bundle-id bundle-id
-                                                   :categories categories})
-  (bundle-content-types/update-bundle-content-types! ds {:bundle-id bundle-id
-                                                         :content-types content-types}))
+  (pg/with-transaction [ds ds]
+    (bundles/update-bundle! ds {:id bundle-id
+                                :data bundle-metadata})
+    (bundle-categories/update-bundle-categories! ds {:bundle-id bundle-id
+                                                     :categories categories})
+    (bundle-content-types/update-bundle-content-types! ds {:bundle-id bundle-id
+                                                           :content-types content-types})))
 
 (defn hard-delete-bundle! [ds js job-id bundle-id]
-  (hon/delete! ds {:tname :filtered-feeds
-                   :where [:= :bundle-id bundle-id]})
-  (hon/delete! ds {:tname :filtered-posts
-                   :where [:= :bundle-id bundle-id]})
-  (hon/delete! ds {:tname :bundle-content-types
-                   :where [:= :bundle-id bundle-id]})
-  (hon/delete! ds {:tname :events
-                   :where [:= :bundle-id bundle-id]})
-  (tables/drop-tables! ds (db.util/tnames [:outgoing-posts
-                                           :bundle-categories
-                                           :post-heuristics]
-                                          bundle-id))
-  (hon/delete! ds {:tname :bundles
-                   :where [:= :id bundle-id]})
-  (congest/deregister! js job-id))
+  (pg/with-transaction [ds ds]
+    (hon/delete! ds {:tname :filtered-feeds
+                     :where [:= :bundle-id bundle-id]})
+    (hon/delete! ds {:tname :filtered-posts
+                     :where [:= :bundle-id bundle-id]})
+    (hon/delete! ds {:tname :bundle-content-types
+                     :where [:= :bundle-id bundle-id]})
+    (hon/delete! ds {:tname :events
+                     :where [:= :bundle-id bundle-id]})
+    (tables/drop-tables! ds (db.util/tnames [:outgoing-posts
+                                             :bundle-categories
+                                             :post-heuristics]
+                                            bundle-id))
+    (hon/delete! ds {:tname :bundles
+                     :where [:= :id bundle-id]})
+    (congest/deregister! js job-id)))
 
 (defn update-filtered-feeds! [ds {:keys [filtered bundle-id feed-id]}]
-  (if filtered
-    (hon/insert! ds {:tname :filtered-feeds
-                     :data {:feed-id feed-id
-                            :bundle-id bundle-id}})
-    (hon/delete! ds {:tname :filtered-feeds
-                     :where [:and
-                             [:= :feed-id feed-id]
-                             [:= :bundle-id bundle-id]]})))
+  (pg/with-transaction [ds ds]
+    (if filtered
+      (hon/insert! ds {:tname :filtered-feeds
+                       :data {:feed-id feed-id
+                              :bundle-id bundle-id}})
+      (hon/delete! ds {:tname :filtered-feeds
+                       :where [:and
+                               [:= :feed-id feed-id]
+                               [:= :bundle-id bundle-id]]}))))
 
 (defn update-filtered-posts! [ds {:keys [filtered bundle-id post-id]}]
-  (if filtered
-    (hon/insert! ds {:tname :filtered-posts
-                     :data {:post-id post-id
-                            :bundle-id bundle-id}})
-    (hon/delete! ds {:tname :filtered-posts
-                     :where [:and
-                             [:= :post-id post-id]
-                             [:= :bundle-id bundle-id]]})))
+  (pg/with-transaction [ds ds]
+    (if filtered
+      (hon/insert! ds {:tname :filtered-posts
+                       :data {:post-id post-id
+                              :bundle-id bundle-id}})
+      (hon/delete! ds {:tname :filtered-posts
+                       :where [:and
+                               [:= :post-id post-id]
+                               [:= :bundle-id bundle-id]]}))))

--- a/src/source/workers/users.clj
+++ b/src/source/workers/users.clj
@@ -1,7 +1,8 @@
 (ns source.workers.users
   (:require [source.workers.feeds :as feeds]
             [source.workers.integrations :as integrations]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [pg.core :as pg]))
 
 (defn hard-delete-creator! [ds js user-id email]
   (let [feed-ids (mapv :id (hon/find ds {:tname :feeds
@@ -18,20 +19,21 @@
                      :where [:= :distributor-id user-id]})))
 
 (defn hard-delete-user! [ds js user-type user-id]
-  (let [{:keys [email business-id]} (hon/find-one ds {:tname :users
-                                                      :where [:= :id user-id]})]
-    (cond
-      (= user-type :creator)
-      (hard-delete-creator! ds js user-id email)
-      (= user-type :distributor)
-      (hard-delete-distributor! ds js user-id))
+  (pg/with-transaction [ds ds]
+    (let [{:keys [email business-id]} (hon/find-one ds {:tname :users
+                                                        :where [:= :id user-id]})]
+      (cond
+        (= user-type :creator)
+        (hard-delete-creator! ds js user-id email)
+        (= user-type :distributor)
+        (hard-delete-distributor! ds js user-id))
 
-    (hon/delete! ds {:tname :user-sectors
-                     :where [:= :user-id user-id]})
-    (when (some? business-id) (hon/delete! ds {:tname :businesses
-                                               :where [:= :id business-id]}))
-    (hon/delete! ds {:tname :users
-                     :where [:= :id user-id]})))
+      (hon/delete! ds {:tname :user-sectors
+                       :where [:= :user-id user-id]})
+      (when (some? business-id) (hon/delete! ds {:tname :businesses
+                                                 :where [:= :id business-id]}))
+      (hon/delete! ds {:tname :users
+                       :where [:= :id user-id]}))))
 
 (defn soft-delete-user! [ds user-id]
   (hon/update! ds {:tname :users


### PR DESCRIPTION
This PR closes #188 

Updated workers/services that write to the database multiple times to use pg/with-transaction. This improves performance and safety by not continuing with other writes unless the previous were successful.