### PR TITLE
email verification

### DIFF
--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -10,6 +10,7 @@ primary_region = 'fra'
 
 [env]
   CORS_ORIGIN = 'https://source-staging.fly.dev'
+  BASE_URL = 'https://source-be-staging.fly.dev'
   DATABASE_DIR = '/data'
   EMAIL_USERNAME = 'merveillevaneck@gmail.com'
   ENV = 'prod'

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,6 +2,7 @@
  :admins-path "resources/admins.json"
  :admins-encrypted-path "resources/admins_encrypted.json"
  :cors-origin #or [#env CORS_ORIGIN "http://localhost:8080"]
+ :base-url #or [#env BASE_URL "https://localhost:3000"]
  :env #or [#env ENV "dev"]
  :database {:url #or [#env DATABASE_URL "postgres://localhost"]
             :type "postgresql"}

--- a/src/source/config.clj
+++ b/src/source/config.clj
@@ -22,6 +22,7 @@
    [:admins-path {:optional true} :string]
    [:admins-encrypted-path :string]
    [:cors-origin :string]
+   [:base-url :string]
    [:env :string]
    [:database [:map
                [:url :string]

--- a/src/source/email/templates.clj
+++ b/src/source/email/templates.clj
@@ -68,6 +68,39 @@
           "The Source Team"]]
         (footer)]]]]]))
 
+(defn email-verification
+  "Returns the completed HTML for a feed rejection email"
+  [{:keys [email-hash]}]
+  (h/html5
+   {:lang "en"}
+   (head-metadata)
+   [:body {:style "font-family: 'Switzer', sans-serif"}
+    [:table {:width "100%" :border "0" :cellspacing "0" :cellpadding "0"}
+     [:tr
+      [:td {:align "center" :style "padding: 20px;"}
+       [:table {:class "content"
+                :width "600"
+                :border "0"
+                :cellspacing "0"
+                :cellpadding "0"
+                :style "border-collapse: collapse; border: 1px solid #cccccc;"}
+        (header)
+        [:tr
+         [:td {:class "body"
+               :style "padding: 40px; text-align: left; font-size: 16px; line-height: 1.6;"}
+          "Welcome to Source!"
+          [:br] [:br]
+          "Thanks for signing up. Please click the button below to verify your email."]]
+        (button {:text "Verify"
+                 :redirect (str (conf/read-value :base-url) "/email/verify/" email-hash)})
+        [:tr
+         [:td {:class "body"
+               :style "padding: 40px; text-align: left; font-size: 16px; line-height: 1.6;"}
+          "Regards,"
+          [:br]
+          "The Source Team"]]
+        (footer)]]]]]))
+
 (defn feed-approval
   "Returns the completed HTML for a feed approval email"
   [{:keys [creator-name feed-title feed-id]}]
@@ -110,38 +143,38 @@
                             (str (subs message 0 15) "...")
                             message)]
     (h/html5
-          {:lang "en"}
-          (head-metadata)
-          [:body {:style "font-family: 'Switzer', sans-serif"}
-           [:table {:width "100%" :border "0" :cellspacing "0" :cellpadding "0"}
-            [:tr
-             [:td {:align "center" :style "padding: 20px;"}
-              [:table {:class "content"
-                       :width "600"
-                       :border "0"
-                       :cellspacing "0"
-                       :cellpadding "0"
-                       :style "border-collapse: collapse; border: 1px solid #cccccc;"}
-               (header)
-               [:tr
-                [:td {:class "body"
-                      :style "padding: 40px; text-align: left; font-size: 16px; line-height: 1.6;"}
-                 "A user has reported a problem:"
-                 [:br] [:br]
-                 message
-                 [:br] [:br]
-                 (str "User ID: " user-id)
-                 [:br]
-                 (str "User email address: " user-email)
-                 [:br]
-                 (str "User type: " user-type)
-                 [:br]
-                 [:br]
-                 "Click on the link below to respond"]]
-               (button {:text "Respond"
-                        :redirect (str "mailto:" user-email "?subject=Source Team Re:" shortened-message)})
-               [:tr
-                [:td {:class "body"
-                      :style "padding: 40px; text-align: left; font-size: 11px; line-height: 1.6;"}
-                 "This is an automated message. Please do not reply directly to this email."]]
-               (footer)]]]]])))
+     {:lang "en"}
+     (head-metadata)
+     [:body {:style "font-family: 'Switzer', sans-serif"}
+      [:table {:width "100%" :border "0" :cellspacing "0" :cellpadding "0"}
+       [:tr
+        [:td {:align "center" :style "padding: 20px;"}
+         [:table {:class "content"
+                  :width "600"
+                  :border "0"
+                  :cellspacing "0"
+                  :cellpadding "0"
+                  :style "border-collapse: collapse; border: 1px solid #cccccc;"}
+          (header)
+          [:tr
+           [:td {:class "body"
+                 :style "padding: 40px; text-align: left; font-size: 16px; line-height: 1.6;"}
+            "A user has reported a problem:"
+            [:br] [:br]
+            message
+            [:br] [:br]
+            (str "User ID: " user-id)
+            [:br]
+            (str "User email address: " user-email)
+            [:br]
+            (str "User type: " user-type)
+            [:br]
+            [:br]
+            "Click on the link below to respond"]]
+          (button {:text "Respond"
+                   :redirect (str "mailto:" user-email "?subject=Source Team Re:" shortened-message)})
+          [:tr
+           [:td {:class "body"
+                 :style "padding: 40px; text-align: left; font-size: 11px; line-height: 1.6;"}
+            "This is an automated message. Please do not reply directly to this email."]]
+          (footer)]]]]])))

--- a/src/source/migrations/013_email_hash.clj
+++ b/src/source/migrations/013_email_hash.clj
@@ -5,6 +5,9 @@
 
 (defn run-up! [context]
   (let [ds-master (:db-master context)]
+    (hon/update! ds-master {:tname :users
+                            :where [:= :type "admin"]
+                            :data {:email-verified 1}})
     (hon/execute!
      ds-master
      (-> (hsql/alter-table :users)

--- a/src/source/migrations/013_email_hash.clj
+++ b/src/source/migrations/013_email_hash.clj
@@ -1,0 +1,18 @@
+(ns source.migrations.013-email-hash
+  (:require [source.db.master]
+            [source.db.honey :as hon]
+            [honey.sql.helpers :as hsql]))
+
+(defn run-up! [context]
+  (let [ds-master (:db-master context)]
+    (hon/execute!
+     ds-master
+     (-> (hsql/alter-table :users)
+         (hsql/add-column :email-hash :text)))))
+
+(defn run-down! [context]
+  (let [ds-master (:db-master context)]
+    (hon/execute!
+     ds-master
+     (-> (hsql/alter-table :users)
+         (hsql/drop-column :email-hash)))))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -5,7 +5,9 @@
             [source.jobs.core :as jobs]
             [source.jobs.handlers :as handlers]
             [congest.jobs :as congest]
-            [source.workers.users :as users]))
+            [source.workers.users :as users]
+            [source.email.gmail :as gmail]
+            [source.email.templates :as templates]))
 
 (defn get
   {:summary "get logged in user by access token"
@@ -60,7 +62,6 @@
     ; TODO: service needed
     (->> (jobs/prepare-congest-metadata
           ds
-          js
           {:id job-id
            :initial-delay (* 1000 60 60 24 30)
            :auto-start true
@@ -86,3 +87,13 @@
     (users/cancel-soft-user-deletion! ds id)
     (congest/deregister! js job-id)
     (res/response {:message "successfully cancelled user deletion"})))
+
+(defn resend-email
+  {:summary "Resend verification email"}
+  [{:keys [ds user]}]
+  (let [{:keys [email email-hash]} (hon/find-one ds {:tname :users
+                                                     :where [:= :id (:id user)]})]
+    (gmail/send-email {:to email
+                       :subject "Source - Verify your email"
+                       :body (templates/email-verification email-hash)
+                       :type :text/html})))

--- a/src/source/routes/me.clj
+++ b/src/source/routes/me.clj
@@ -7,7 +7,8 @@
             [congest.jobs :as congest]
             [source.workers.users :as users]
             [source.email.gmail :as gmail]
-            [source.email.templates :as templates]))
+            [source.email.templates :as templates]
+            [source.routes.openapi :as api]))
 
 (defn get
   {:summary "get logged in user by access token"
@@ -28,7 +29,7 @@
   [{:keys [ds user] :as _request}]
   (let [user (hon/find-one ds {:tname :users
                                :where [:= :id (:id user)]})]
-    (->> (dissoc user :password)
+    (->> (dissoc user :password :email-hash)
          (res/response))))
 
 (defn post
@@ -89,11 +90,13 @@
     (res/response {:message "successfully cancelled user deletion"})))
 
 (defn resend-email
-  {:summary "Resend verification email"}
+  {:summary "Resend verification email"
+   :responses (api/success (api/response-schema))}
   [{:keys [ds user]}]
   (let [{:keys [email email-hash]} (hon/find-one ds {:tname :users
                                                      :where [:= :id (:id user)]})]
     (gmail/send-email {:to email
                        :subject "Source - Verify your email"
-                       :body (templates/email-verification email-hash)
-                       :type :text/html})))
+                       :body (templates/email-verification {:email-hash email-hash})
+                       :type :text/html})
+    (res/response {:message "successfully resent email-verification email"})))

--- a/src/source/routes/register.clj
+++ b/src/source/routes/register.clj
@@ -1,7 +1,6 @@
 (ns source.routes.register
   (:require [source.services.interface :as services]
             [ring.util.response :as res]
-            [source.util :as util]
             [source.db.honey :as hon]))
 
 (defn post

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -91,6 +91,8 @@
       ["/:id" (-> (get user/get)
                   (patch user/patch))]]
 
+     ["/email/verify/:hash" (get user/verify-email)]
+
      ["/me" {:middleware [[mw/apply-auth]]
              :tags #{"me"}
              :swagger {:security [{"auth" []}]}
@@ -99,6 +101,7 @@
       ["" (-> (get me/get)
               (post me/post)
               (delete me/delete-user))]
+      ["/email/resend" (get me/resend-email)]
       ["/deletion/cancel" (get me/cancel-deletion)]
       ["/business" (-> (get me-business/get)
                        (post me-business/post))]
@@ -232,6 +235,7 @@
                 :swagger {:security [{"auth" []}]}
                 :openapi {:security [{:bearerAuth []}]}}
 
+      ["/users/:id/verify" (get users/verify-email)]
       ["/business/types" (-> (post business-types/post)
                              (patch business-types/patch)
                              (delete business-types/delete))]

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -1,7 +1,8 @@
 (ns source.routes.user
   (:require [ring.util.response :as res]
-            [source.util :as util]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.routes.openapi :as api]
+            [source.config :as conf]))
 
 (defn get
   {:summary "get user by id"
@@ -65,6 +66,27 @@
                    :where [:= :id (:id path-params)]
                    :data body})
   (res/response {:message "successfully updated user"}))
+
+(defn verify-email
+  {:summary "verify user email with email hash"
+   :parameters (api/params :path [:map [:hash :string]])
+   :responses {302 {:body [:map [:message :string]]}
+               403 {:body [:map [:message :string]]}}}
+  [{:keys [ds path-params]}]
+  (let [email-hash (:hash path-params)
+        user (hon/find-one ds {:tname :users
+                               :where [:= :email-hash email-hash]})]
+    (if (some? user)
+      (do
+        (hon/update! ds {:tname :users
+                         :where [:= :id (:id user)]
+                         :data {:email-verified true
+                                :email-hash ""}})
+        (-> (conf/read-value :cors-origin)
+            (str "/dashboard/onboarding")
+            (res/redirect)))
+      (-> (res/response {:message "unauthorized"})
+          (res/status 403)))))
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -70,8 +70,8 @@
 (defn verify-email
   {:summary "verify user email with email hash"
    :parameters (api/params :path [:map [:hash :string]])
-   :responses {302 {:body [:map [:message :string]]}
-               403 {:body [:map [:message :string]]}}}
+   :responses {302 (api/response-schema)
+               403 (api/response-schema)}}
   [{:keys [ds path-params]}]
   (let [email-hash (:hash path-params)
         user (hon/find-one ds {:tname :users

--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -80,7 +80,7 @@
       (do
         (hon/update! ds {:tname :users
                          :where [:= :id (:id user)]
-                         :data {:email-verified true
+                         :data {:email-verified 1
                                 :email-hash ""}})
         (-> (conf/read-value :cors-origin)
             (str "/dashboard/onboarding")

--- a/src/source/routes/users.clj
+++ b/src/source/routes/users.clj
@@ -1,6 +1,7 @@
 (ns source.routes.users
   (:require [ring.util.response :as res]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.routes.openapi :as api]))
 
 (defn get
   {:summary "get all users"
@@ -24,6 +25,15 @@
   [{:keys [ds] :as _request}]
   (res/response {:users (hon/find ds {:tname :users
                                       :ret :*})}))
+
+(defn verify-email
+  {:summary "verify user email with email hash"
+   :parameters (api/params :path [:map [:id :int]])
+   :responses (api/success (api/response-schema))}
+  [{:keys [ds path-params]}]
+  (hon/update! ds {:tname :users
+                   :where [:= :id (:id path-params)]
+                   :data {:email-verified true}}))
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/routes/users.clj
+++ b/src/source/routes/users.clj
@@ -33,7 +33,9 @@
   [{:keys [ds path-params]}]
   (hon/update! ds {:tname :users
                    :where [:= :id (:id path-params)]
-                   :data {:email-verified true}}))
+                   :data {:email-verified 1
+                          :email-hash ""}})
+  (res/response {:message "successfully verified user"}))
 
 (comment
   (require '[source.db.interface :as db])

--- a/src/source/services/auth.clj
+++ b/src/source/services/auth.clj
@@ -7,7 +7,7 @@
 
 (defn login [ds {:keys [user] :as _login}]
   (merge
-   {:user (dissoc user :password)}
+   {:user (dissoc user :password :email-hash)}
    (auth/create-session (select-keys user [:id :type]))))
 
 (defn register [ds {:keys [email password] :as user}]
@@ -18,12 +18,12 @@
                                     :email-hash (pw/hash-password email)))})
   (gmail/send-email {:to email
                      :subject "Source - Verify your email"
-                     :body (templates/email-verification (pw/hash-password email))
+                     :body (templates/email-verification {:email-hash (pw/hash-password email)})
                      :type :text/html})
   (let [user (hon/find-one ds {:tname :users
                                :where [:= :email email]})]
     (merge
-     {:user (dissoc user :password)}
+     {:user (dissoc user :password :email-hash)}
      (auth/create-session (select-keys user [:id :type])))))
 
 (comment

--- a/src/source/services/auth.clj
+++ b/src/source/services/auth.clj
@@ -1,7 +1,9 @@
 (ns source.services.auth
   (:require [source.password :as pw]
             [source.middleware.auth.core :as auth]
-            [source.db.honey :as hon]))
+            [source.db.honey :as hon]
+            [source.email.gmail :as gmail]
+            [source.email.templates :as templates]))
 
 (defn login [ds {:keys [user] :as _login}]
   (merge
@@ -12,7 +14,12 @@
   (hon/insert! ds {:tname :users
                    :data (-> user
                              (dissoc :confirm-password)
-                             (assoc :password (pw/hash-password password)))})
+                             (assoc :password (pw/hash-password password)
+                                    :email-hash (pw/hash-password email)))})
+  (gmail/send-email {:to email
+                     :subject "Source - Verify your email"
+                     :body (templates/email-verification (pw/hash-password email))
+                     :type :text/html})
   (let [user (hon/find-one ds {:tname :users
                                :where [:= :email email]})]
     (merge


### PR DESCRIPTION
- implemented email verification endpoints
- added admin endpoint to verify any user's email
- added migration to ensure all admin accounts have verified emails and to create the email hash field

On registration, an email will be sent to the user's email address with a link to a backend verification endpoint using the email hash. Clicking on the link will call the endpoint, verifying the email, which then redirects to the frontend onboarding page. There is a user-protected endpoint to resend the verification email.

This closes #212 