### PR TITLE
integration types

### DIFF
--- a/src/source/db/master.clj
+++ b/src/source/db/master.clj
@@ -260,6 +260,12 @@
    (tables/table-id)
    [:name :text :not nil]))
 
+(def integration-types
+  (tables/create-table-sql
+   :business-types
+   (tables/table-id)
+   [:name :text :not nil]))
+
 (comment
   (require '[honey.sql :as sql])
 
@@ -284,6 +290,7 @@
   (sql/format filtered-feeds)
   (sql/format filtered-posts)
   (sql/format business-types)
+  (sql/format integration-types)
 
   (sql/format events)
   (sql/format event-categories)

--- a/src/source/migrations/015_integration_types.clj
+++ b/src/source/migrations/015_integration_types.clj
@@ -1,0 +1,32 @@
+(ns source.migrations.015-integration-types
+  (:require [source.db.master]
+            [source.db.honey :as hon]
+            [honey.sql.helpers :as hsql]
+            [source.db.tables :as tables]))
+
+(defn run-up! [context]
+  (let [ds-master (:db-master context)]
+    (tables/create-table!
+     ds-master
+     :source.db.master
+     :integration-types)
+
+    (hon/insert! ds-master {:tname :integration-types
+                            :data [{:name "Website"}
+                                   {:name "App"}
+                                   {:name "Plugin"}
+                                   {:name "Community"}]})
+
+    (hon/execute!
+     ds-master
+     (-> (hsql/alter-table :bundles)
+         (hsql/add-column :integration-id :int)))))
+
+(defn run-down! [context]
+  (let [ds-master (:db-master context)]
+    (hon/execute!
+     ds-master
+     (-> (hsql/alter-table :bundles)
+         (hsql/drop-column :integration-id)))
+
+    (tables/drop-table! ds-master :integration-types)))

--- a/src/source/routes/integration.clj
+++ b/src/source/routes/integration.clj
@@ -6,27 +6,17 @@
             [congest.jobs :as congest]
             [source.jobs.core :as jobs]
             [source.util :as util]
-            [source.jobs.handlers :as handlers]))
+            [source.jobs.handlers :as handlers]
+            [source.workers.schemas :as schemas]
+            [malli.util :as mu]
+            [source.routes.openapi :as api]))
 
 (defn get
   {:summary "Get metadata of integration by ID"
    :parameters {:path [:map [:id {:title "id"
                                   :description "Integration ID"} :int]]}
-   :responses {200 {:body [:map
-                           [:id :int]
-                           [:name :string]
-                           [:uuid :string]
-                           [:user-id :int]
-                           [:video :int]
-                           [:podcast :int]
-                           [:blog :int]
-                           [:hash [:maybe :string]]
-                           [:content-type-id :int]
-                           [:ts-and-cs [:maybe :int]]
-                           [:content-types [:vector
-                                            [:map
-                                             [:id :int]
-                                             [:name :string]]]]]}
+   :responses {200 {:body (-> schemas/Bundle
+                              (mu/assoc :content-types schemas/ContentTypes))}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
@@ -40,16 +30,11 @@
    :description "When the integration is updated, post selection is rerun based on the newly set desired categories and content types."
    :parameters {:path [:map [:id {:title "id"
                                   :description "Integration ID"} :int]]
-                :body [:map
-                       [:name :string]
-                       [:content-types [:vector
-                                        [:map
-                                         [:id :int]
-                                         [:name :string]]]]
-                       [:categories [:vector
-                                     [:map
-                                      [:id :int]
-                                      [:name :string]]]]]}
+                :body (-> [:map
+                           [:name :string]
+                           [:integration-type-id :int]]
+                          (mu/assoc :content-types [:vector schemas/ConstantSchema])
+                          (mu/assoc :categories [:vector schemas/ConstantSchema]))}
    :responses {200 {:body [:map [:message :string]]}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
@@ -86,8 +71,8 @@
    :description "Deletes the integration, bundle and kills the associated post selection job. This action cannot be undone."
    :parameters {:path [:map [:id {:title "id"
                                   :description "Integration ID"} :int]]}
-   :responses {200 {:body [:map [:message :string]]}
-               403 {:body [:map [:message :string]]}}}
+   :responses {200 {:body (api/response-schema)}
+               403 {:body (api/response-schema)}}}
 
   [{:keys [ds js user path-params] :as _request}]
   (let [bundle-id (:id path-params)

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -5,22 +5,15 @@
             [source.util :as util]
             [source.jobs.core :as jobs]
             [source.jobs.handlers :as handlers]
-            [congest.jobs :as congest]))
+            [congest.jobs :as congest]
+            [source.routes.openapi :as api]
+            [source.workers.schemas :as schemas]
+            [source.db.honey :as hon]
+            [malli.util :as mu]))
 
 (defn get
   {:summary "Get metadata of all integrations on the user account"
-   :responses {200 {:body [:vector
-                           [:map
-                            [:id :int]
-                            [:name :string]
-                            [:uuid :string]
-                            [:user-id :int]
-                            [:video :int]
-                            [:podcast :int]
-                            [:blog :int]
-                            [:hash [:maybe :string]]
-                            [:content-type-id :int]
-                            [:ts-and-cs [:maybe :int]]]]}
+   :responses {200 {:body schemas/Bundles}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
@@ -30,28 +23,13 @@
 (defn post
   {:summary "Creates an integration and the associated bundle in which content is stored"
    :description "When an integration is created, a job is scheduled to periodically run post selection every 24 hours. During post selection, the bundle is filled with relevant content according to desired categories, content types and analytics."
-   :parameters {:body [:map
-                       [:name :string]
-                       [:ts-and-cs {:optional true} :int]
-                       [:content-types [:vector
-                                        [:map
-                                         [:id :int]
-                                         [:name :string]]]]
-                       [:categories [:vector
-                                     [:map
-                                      [:id :int]
-                                      [:name :string]]]]]}
-   :responses {201 {:body [:map
-                           [:id :int]
+   :parameters {:body (-> [:map
                            [:name :string]
-                           [:uuid :string]
-                           [:user-id :int]
-                           [:video :int]
-                           [:podcast :int]
-                           [:blog :int]
-                           [:hash {:optional true} [:maybe :string]]
-                           [:content-type-id :int]
-                           [:ts-and-cs {:optional true} :int]]}
+                           [:ts-and-cs {:optional true} :int]
+                           [:integration-type-id :int]]
+                          (mu/assoc :content-types [:vector schemas/ConstantSchema])
+                          (mu/assoc :categories [:vector schemas/ConstantSchema]))}
+   :responses {201 {:body schemas/Bundle}
                401 {:body [:map [:message :string]]}
                403 {:body [:map [:message :string]]}}}
 
@@ -78,3 +56,9 @@
            :sleep false})
          (congest/register! js))
     (res/response new-bundle)))
+
+(defn get-integration-types
+  {:summary "get all integration types"
+   :responses (api/success schemas/IntegrationTypes)}
+  [{:keys [ds]}]
+  (res/response (hon/find ds {:tname :integration-types})))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -187,6 +187,9 @@
       ["/:id/filter/posts/:post-id" (-> (get integration-filter-post/get)
                                         (post integration-filter-post/post))]]
 
+     ["/integration/types" {:tags #{"integrations"}}
+      ["" (get integrations/get-integration-types)]]
+
      ["/feeds" {:middleware [[mw/apply-auth]]
                 :tags #{"feeds"}}
 
@@ -228,7 +231,8 @@
       ["/feeds/:id/posts/:post-id" (get bundle-feed-post/get)]
       ["/posts" (post bundle-posts/post)]
       ["/posts/:id" (get bundle-post/get)]]
-     ["/bundle/exists" (get bundle/exists)]
+     ["/bundle/exists" {:tags #{"bundles"}}
+      ["" (get bundle/exists)]]
 
      ["/admin" {:middleware [[mw/apply-auth {:required-type :admin}]]
                 :tags #{"admin"}

--- a/src/source/workers/schemas.clj
+++ b/src/source/workers/schemas.clj
@@ -232,16 +232,28 @@
 (def JobsWithMetadata
   [:vector JobWithMetadata])
 
+(def IntegrationType
+  ConstantSchema)
+
+(def IntegrationTypes
+  [:vector IntegrationType])
+
 (def Bundle
   [:map
    [:id :int]
    [:name :string]
    [:uuid :string]
+   [:user-id :int]
    [:video :int]
    [:podcast :int]
    [:blog :int]
-   [:hash :string]
-   [:ts-and-cs :int]])
+   (api/sometimes :hash :string)
+   [:content-type-id :int]
+   (api/sometimes :integration-type-id :int)
+   [:ts-and-cs {:optional true} :int]])
+
+(def Bundles
+  [:vector Bundle])
 
 (def BundleWithUser
   (-> Bundle


### PR DESCRIPTION
This PR closes #220 

- added migration to add and seed integration types, adds integration type id to bundles table
- added endpoint to get all integration types
- updated integration endpoint schemas to add integration type id and use top-level schemas
- updated add/update integration endpoints to also add/update the integration type id
