### PR TITLE
block deleted user writes

### DIFF
--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -51,7 +51,7 @@
         (and (= user-type (name required-type)) (= user-type expected-type)) (handler request)
         :else (->
                (res/response {:message "Unauthorized"})
-               (res/status 403))))))
+               (res/status 401))))))
 
 (defn wrap-bundle-id
   "validates the bundle uuid in the query parameters of the request for 

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -17,15 +17,21 @@
       (util/auth-token)
       (util/verify-jwt)))
 
-(defn wrap-auth [handler]
+(defn wrap-auth
+  "Returns unauthenticated if the user JWT validation failed, or if a soft-deleted user tries to call a non-GET endpoint"
+  [handler]
   (fn [request]
-    (if-let [user (validate-request request)]
-      (-> request
-          (assoc :user user)
-          (handler))
-      (->
-       (res/response {:message "Unauthorized"})
-       (res/status 401)))))
+    (let [ds (db.util/conn :master)
+          {:keys [id] :as user} (validate-request request)
+          {:keys [removed]} (db/find-one ds {:tname :users
+                                             :where [:= :id id]})]
+      (if (and user (if (= (:request-method request) :get) true (= removed 0)))
+        (-> request
+            (assoc :user user)
+            (handler))
+        (->
+         (res/response {:message "Unauthorized"})
+         (res/status 401))))))
 
 (defn wrap-auth-user-type
   "returns an unauthorized response if the user's type is not the required user type (creator | distributor | admin)"

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -20,15 +20,18 @@
 (defn wrap-auth
   "Returns unauthenticated if the user JWT validation failed, or if a soft-deleted user tries to call a non-GET endpoint"
   [handler]
-  (fn [request]
-    (let [ds (db.util/conn :master)
-          {:keys [id] :as user} (validate-request request)
+  (fn [{:keys [ds] :as request}]
+    (let [{:keys [id] :as user} (validate-request request)
           {:keys [removed]} (db/find-one ds {:tname :users
                                              :where [:= :id id]})]
-      (if (and user (if (= (:request-method request) :get) true (= removed 0)))
-        (-> request
-            (assoc :user user)
-            (handler))
+      (if user
+        (if (or (= (:request-method request) :get) (= removed 0))
+          (-> request
+              (assoc :user user)
+              (handler))
+          (->
+           (res/response {:message "The account of the user attempting to use this endpoint has been archived."})
+           (res/status 403)))
         (->
          (res/response {:message "Unauthorized"})
          (res/status 401))))))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -108,11 +108,7 @@
       ["/sectors" (-> (get me-sectors/get)
                       (post me-sectors/post))]]
 
-     ["/mail" {:middleware [[mw/apply-auth]]
-               :tags #{"mail"}
-               :swagger {:security [{"auth" []}]}
-               :openapi {:security [{:bearerAuth []}]}}
-
+     ["/mail" {:tags #{"mail"}}
       ["/report" (post report/post)]]
 
      ["/businesses" {:middleware [[mw/apply-auth {:required-type :admin}]]


### PR DESCRIPTION
This PR closes #216 

Updated the authentication middleware such that soft-deleted users will not be able to use non-GET endpoints. This means that users who have deleted their account will only be able to read data, and not modify them. 

All endpoints on the system that authenticated users interact with are already set up in such a way that endpoints with GET methods are only reads.

This could also be done with a separate middleware that simply checks if a user is soft-deleted or not; however, this is a lot more work to do than expected as Reitit makes it complex to have different middleware on specific methods of an endpoint.