### PR TITLE
db connection by environment

### DIFF
--- a/resources/dev_config.edn
+++ b/resources/dev_config.edn
@@ -7,7 +7,6 @@
  :env #or [#env ENV "dev"]
  :database {:url #or [#env DATABASE_URL "postgres://localhost"]
             :type "postgresql"
-            :dev #or [#env DEV_DATABASE_URL "postgres://localhost:5432"]
             :staging #or [#env STAGING_DATABASE_URL "postgres://username:password@localhost:16380"]
             :prod #or [#env PROD_DATABASE_URL "postgres://username:password@localhost:16380"]}
  :email {:address #or [#env SUPPORT_ADDRESS "lee@wearesource.earth"]

--- a/resources/dev_config.edn
+++ b/resources/dev_config.edn
@@ -6,7 +6,10 @@
  :port #or [#env PORT 3000]
  :env #or [#env ENV "dev"]
  :database {:url #or [#env DATABASE_URL "postgres://localhost"]
-            :type "postgresql"}
+            :type "postgresql"
+            :dev #or [#env DEV_DATABASE_URL "postgres://localhost:5432"]
+            :staging #or [#env STAGING_DATABASE_URL "postgres://fly-user:password@localhost:16380"]
+            :prod #or [#env PROD_DATABASE_URL "postgres://fly-user:password@localhost:16380"]}
  :email {:address #or [#env SUPPORT_ADDRESS "lee@wearesource.earth"]
          :username #env EMAIL_USERNAME
          :password #env EMAIL_PASSWORD}

--- a/resources/dev_config.edn
+++ b/resources/dev_config.edn
@@ -8,8 +8,8 @@
  :database {:url #or [#env DATABASE_URL "postgres://localhost"]
             :type "postgresql"
             :dev #or [#env DEV_DATABASE_URL "postgres://localhost:5432"]
-            :staging #or [#env STAGING_DATABASE_URL "postgres://fly-user:password@localhost:16380"]
-            :prod #or [#env PROD_DATABASE_URL "postgres://fly-user:password@localhost:16380"]}
+            :staging #or [#env STAGING_DATABASE_URL "postgres://username:password@localhost:16380"]
+            :prod #or [#env PROD_DATABASE_URL "postgres://username:password@localhost:16380"]}
  :email {:address #or [#env SUPPORT_ADDRESS "lee@wearesource.earth"]
          :username #env EMAIL_USERNAME
          :password #env EMAIL_PASSWORD}

--- a/src/source/db/util.clj
+++ b/src/source/db/util.clj
@@ -39,10 +39,15 @@
 (defn tnames [tnames id]
   (mapv #(:tname (tname % id)) tnames))
 
-(defn conn-env [env]
+(defn conn-env 
+  "Creates a connection to the master database for the given environment. There must be a connection string in config for the given environment."
+  [env]
   {:connection-uri (str (conf/read-value :database env) "/master")})
 
-(defmacro with-env [args & body]
+(defmacro with-env 
+  "This macro creates a let binding structure associating a custom binding with a database connection based with the given environment as a keyword.
+  e.g. (with-env [ds :staging] (hon/find ds {:tname :users}))"
+  [args & body]
   `(let [~(first args) (conn-env ~(last args))]
      ~(cons 'do body)))
 

--- a/src/source/db/util.clj
+++ b/src/source/db/util.clj
@@ -39,8 +39,22 @@
 (defn tnames [tnames id]
   (mapv #(:tname (tname % id)) tnames))
 
+(defn conn-env [env]
+  {:connection-uri (str (conf/read-value :database env) "/master")})
+
+(defmacro with-env [args & body]
+  `(let [~(first args) (conn-env ~(last args))]
+     ~(cons 'do body)))
+
 (comment
   (def q "SELECT * FROM events")
+
+  (macroexpand '(with-env [ds :staging] (println ds)))
+
+  (with-env [ds :staging]
+    (time (pg/with-conn [conn ds]
+            (pg/query conn q)))
+    #_(hon/find ds {:tname :users}))
 
   (time (pg/with-conn [conn {:connection-uri "postgresql://postgres:postgres@localhost:5432/master?ssl=false"}]
           (pg/query conn q)))


### PR DESCRIPTION
Added macro to create a connection instance binding by environment as a keyword.

e.g.
```clojure
(with-env [ds :staging]
    (hon/find ds {:tname :users}))
```

Do note that this requires us to have a connection string to our postgres instance on staging / prod. We will need to get this exposed in some way.
