### PR TITLE
delete user sectors

### DIFF
--- a/src/source/migrations/018_sector_seeding.clj
+++ b/src/source/migrations/018_sector_seeding.clj
@@ -6,12 +6,14 @@
   (let [ds-master (:db-master context)
         sectors (->> (hon/find ds-master {:tname :categories})
                      (mapv #(dissoc % :display-picture)))]
+    (hon/delete! ds-master {:tname :user-sectors})
     (hon/delete! ds-master {:tname :sectors})
     (hon/insert! ds-master {:tname :sectors
                             :data sectors})))
 
 (defn run-down! [context]
   (let [ds-master (:db-master context)]
+    (hon/delete! ds-master {:tname :user-sectors})
     (hon/delete! ds-master {:tname :sectors})
     (hon/insert! ds-master {:tname :sectors
                             :data [{:name "renewable energy"}


### PR DESCRIPTION
User sectors need to be deleted before sectors are deleted. Updated sector seeding migration to do this.

