### PR TITLE
provide password to ssh action

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           host: mervstation.tail4f070.ts.net
           username: merv
+          password: tailscale
           script: |
             cd /home/merv/Developer/source-be
             git pull


### PR DESCRIPTION
appleboy/ssh needs a password to work, even though we don't need one because we're using tailscale. We are able to provide any string in there, in this case 'tailscale', just so that it doesn't complain.
