### PR TITLE
truncation-ellipsis

### DIFF
--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -49,7 +49,7 @@
    :p.content-type-id
    :p.title
    :p.thumbnail
-   (if (= truncate "false") :p.info [[:left :p.info 100] :info])
+   (if (= truncate "false") :p.info [[:|| [:left :p.info 100] "..."] :info])
    :p.url
    :p.stream-url
    :p.season


### PR DESCRIPTION
Concatenated an ellipsis to the end of the truncated description string. This makes the string look a bit cleaner if it's truncated.

<img width="330" height="230" alt="image" src="https://github.com/user-attachments/assets/a1426f10-5889-4986-bac8-cd760dbf2e84" />
