### PR TITLE
replace 403 with redirect

### DIFF
--- a/src/source/routes/user.clj
+++ b/src/source/routes/user.clj
@@ -85,8 +85,9 @@
         (-> (conf/read-value :cors-origin)
             (str "/dashboard/onboarding")
             (res/redirect)))
-      (-> (res/response {:message "unauthorized"})
-          (res/status 403)))))
+      (-> (conf/read-value :cors-origin)
+          (str "/dashboard/onboarding")
+          (res/redirect)))))
 
 (comment
   (require '[source.db.interface :as db])


### PR DESCRIPTION
Replaces Unauthorized response in email verification with the same redirect response to the frontend as the successful route. The frontend will simply tell the user to verify first, much better than an ugly json response from the backend.
