### PR TITLE
post date ordering

### DIFF
--- a/src/source/routes/bundle_feed_posts.clj
+++ b/src/source/routes/bundle_feed_posts.clj
@@ -32,6 +32,7 @@
 
   [{:keys [ds bundle-id path-params] :as _request}]
   (let [posts (hon/find ds {:tname :incoming-posts
+                            :order-by [[:posted-at :desc]]
                             :where [:= :feed-id (:id path-params)]
                             :ret :*})]
     (try

--- a/src/source/routes/posts.clj
+++ b/src/source/routes/posts.clj
@@ -27,6 +27,7 @@
 
   [{:keys [ds path-params] :as _request}]
   (-> (hon/find ds {:tname :incoming-posts
+                    :order-by [[:posted-at :desc]]
                     :where [:= :feed-id (:id path-params)]
                     :ret :*})
       (res/response)))


### PR DESCRIPTION
Updated post endpoints for creators/admins to view posts in descending order by date, as well as for the channel posts page on the embed.
