### PR TITLE
refresh bundle

### DIFF
--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -20,7 +20,7 @@
 
 (defmethod handler :test [_]
   (fn [{:keys [args]}]
-    (println "hello" (:name args) args)))
+    (println "hello" (get args :name) args)))
 
 (defn update-feed-posts-job-id
   "returns the job id of an update-feed-posts job with the given email and feed-id"

--- a/src/source/jobs/handlers.clj
+++ b/src/source/jobs/handlers.clj
@@ -20,7 +20,7 @@
 
 (defmethod handler :test [_]
   (fn [{:keys [args]}]
-    (println "hello" (get args :name) args)))
+    (println "hello" (:name args) args)))
 
 (defn update-feed-posts-job-id
   "returns the job id of an update-feed-posts job with the given email and feed-id"

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -58,22 +58,22 @@
   "returns an unauthorized response if the integration id is not owned by this user and the user is not an admin"
   [handler]
   (fn [{:keys [ds user path-params] :as request}]
-    (cond
-      (= (:type user) "admin")
-      (handler request)
+    (let [bundle-id (try (Integer/parseInt (:id path-params)) (catch Exception _ nil))]
+      (cond
+        (nil? bundle-id)
+        (-> (res/response {:message "unauthorized"})
+            (res/status 403))
 
-      (and (= (:type user) "distributor")
-           (bundles-worker/user-owns-bundle?
-            ds
-            (:id user)
-            (try
-              (Integer/parseInt (:id path-params))
-              (catch Exception _ nil))))
-      (handler request)
+        (= (:type user) "admin")
+        (handler request)
 
-      :else
-      (-> (res/response {:message "unauthorized"})
-          (res/status 401)))))
+        (and (= (:type user) "distributor")
+             (bundles-worker/user-owns-bundle? ds bundle-id (:id user)))
+        (handler request)
+
+        :else
+        (-> (res/response {:message "unauthorized"})
+            (res/status 403))))))
 
 (defn wrap-bundle-id
   "validates the bundle uuid in the query parameters of the request for 

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -5,8 +5,7 @@
             [source.services.bundles :as bundles]
             [source.db.honey :as db]
             [taoensso.telemere :as t]
-            [source.db.honey :as hon]
-            [pg.core :as pg]))
+            [source.workers.bundles :as bundles-worker]))
 
 (defn create-session [user]
   (let [payload {:id (:id user)
@@ -64,15 +63,12 @@
       (handler request)
 
       (and (= (:type user) "distributor")
-           (->
-            (pg/execute
-             ds
-             "SELECT EXISTS(SELECT 1 FROM bundles WHERE id = $1 AND user_id = $2) AS exists"
-             {:params [(Integer/parseInt (:id path-params))
-                       (:id user)]})
-            (first)
-            (:exists)))
-
+           (bundles-worker/user-owns-bundle?
+            ds
+            (:id user)
+            (try
+              (Integer/parseInt (:id path-params))
+              (catch Exception _ nil))))
       (handler request)
 
       :else

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -64,11 +64,15 @@
       (handler request)
 
       (and (= (:type user) "distributor")
-           (pg/execute
-            ds
-            "SELECT EXISTS(SELECT 1 FROM bundles WHERE id = $1 AND user_id = $2) AS exists"
-            {:params [(:id path-params)
-                      (:id user)]}))
+           (->
+            (pg/execute
+             ds
+             "SELECT EXISTS(SELECT 1 FROM bundles WHERE id = $1 AND user_id = $2) AS exists"
+             {:params [(Integer/parseInt (:id path-params))
+                       (:id user)]})
+            (first)
+            (:exists)))
+
       (handler request)
 
       :else

--- a/src/source/middleware/auth/core.clj
+++ b/src/source/middleware/auth/core.clj
@@ -4,7 +4,9 @@
             [ring.util.response :as res]
             [source.services.bundles :as bundles]
             [source.db.honey :as db]
-            [taoensso.telemere :as t]))
+            [taoensso.telemere :as t]
+            [source.db.honey :as hon]
+            [pg.core :as pg]))
 
 (defn create-session [user]
   (let [payload {:id (:id user)
@@ -52,6 +54,26 @@
         :else (->
                (res/response {:message "Unauthorized"})
                (res/status 401))))))
+
+(defn wrap-integration-auth
+  "returns an unauthorized response if the integration id is not owned by this user and the user is not an admin"
+  [handler]
+  (fn [{:keys [ds user path-params] :as request}]
+    (cond
+      (= (:type user) "admin")
+      (handler request)
+
+      (and (= (:type user) "distributor")
+           (pg/execute
+            ds
+            "SELECT EXISTS(SELECT 1 FROM bundles WHERE id = $1 AND user_id = $2) AS exists"
+            {:params [(:id path-params)
+                      (:id user)]}))
+      (handler request)
+
+      :else
+      (-> (res/response {:message "unauthorized"})
+          (res/status 401)))))
 
 (defn wrap-bundle-id
   "validates the bundle uuid in the query parameters of the request for 

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -62,3 +62,19 @@
    :responses (api/success schemas/IntegrationTypes)}
   [{:keys [ds]}]
   (res/response (hon/find ds {:tname :integration-types})))
+
+(defn refresh
+  {:summary "Force rerun of bundle job to refresh integration content"
+   :parameters (api/params :path [:map [:id {:description "Integration ID"} :int]])
+   :responses (-> (api/success [:map [:message :string]])
+                  (api/unauthorized nil))}
+  [{:keys [ds js user path-params]}]
+  (let [{:keys [user-id]} (hon/find-one ds {:tname :bundles
+                                            :where [:= :id (:id path-params)]})
+        job-id (handlers/update-bundle-job-id (:id path-params))]
+    (if (or (= user-id (:id user)) (= (:type user) "admin"))
+      (do
+        (congest/stop! js job-id false)
+        (jobs/start! js ds job-id)
+        (res/response {:message "Successfully restarted bundle job."}))
+      (res/response {:message "unauthorized"}))))

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -69,19 +69,14 @@
    :parameters (api/params :path [:map [:id {:description "Integration ID"} :int]])
    :responses (-> (api/success [:map [:message :string]])
                   (api/unauthorized nil))}
-  [{:keys [ds user path-params]}]
+  [{:keys [ds path-params]}]
   (let [bundle-id (:id path-params)
-        {:keys [user-id]} (hon/find-one ds {:tname :bundles
-                                            :where [:= :id bundle-id]})
         categories (->> (-> {:where [:= :bundle-id bundle-id]}
                             (db.util/tname :bundle-categories bundle-id))
                         (hon/find ds)
                         (mapv #(assoc {} :id (:category-id %))))]
-    (if (or (= user-id (:id user)) (= (:type user) "admin"))
-      (do
-        ((handlers/handler {:handler :update-bundle})
-         {:ds ds
-          :args {:bundle-id bundle-id
-                 :categories categories}})
-        (res/response {:message "Successfully restarted bundle job."}))
-      (res/response {:message "unauthorized"}))))
+    ((handlers/handler {:handler :update-bundle})
+     {:ds ds
+      :args {:bundle-id bundle-id
+             :categories categories}})
+    (res/response {:message "Successfully restarted bundle job."})))

--- a/src/source/routes/integrations.clj
+++ b/src/source/routes/integrations.clj
@@ -9,7 +9,8 @@
             [source.routes.openapi :as api]
             [source.workers.schemas :as schemas]
             [source.db.honey :as hon]
-            [malli.util :as mu]))
+            [malli.util :as mu]
+            [source.db.util :as db.util]))
 
 (defn get
   {:summary "Get metadata of all integrations on the user account"
@@ -68,13 +69,19 @@
    :parameters (api/params :path [:map [:id {:description "Integration ID"} :int]])
    :responses (-> (api/success [:map [:message :string]])
                   (api/unauthorized nil))}
-  [{:keys [ds js user path-params]}]
-  (let [{:keys [user-id]} (hon/find-one ds {:tname :bundles
-                                            :where [:= :id (:id path-params)]})
-        job-id (handlers/update-bundle-job-id (:id path-params))]
+  [{:keys [ds user path-params]}]
+  (let [bundle-id (:id path-params)
+        {:keys [user-id]} (hon/find-one ds {:tname :bundles
+                                            :where [:= :id bundle-id]})
+        categories (->> (-> {:where [:= :bundle-id bundle-id]}
+                            (db.util/tname :bundle-categories bundle-id))
+                        (hon/find ds)
+                        (mapv #(assoc {} :id (:category-id %))))]
     (if (or (= user-id (:id user)) (= (:type user) "admin"))
       (do
-        (congest/stop! js job-id false)
-        (jobs/start! js ds job-id)
+        ((handlers/handler {:handler :update-bundle})
+         {:ds ds
+          :args {:bundle-id bundle-id
+                 :categories categories}})
         (res/response {:message "Successfully restarted bundle job."}))
       (res/response {:message "unauthorized"}))))

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -178,6 +178,7 @@
       ["/:id" (-> (get integration/get)
                   (post integration/post)
                   (delete integration/delete))]
+      ["/:id/refresh" (get integrations/refresh)]
       ["/:id/categories" (-> (get integration-categories/get)
                              (post integration-categories/post))]
       ["/:id/filter/feeds" (get integration-filter-feeds/get)]

--- a/src/source/routes/reitit.clj
+++ b/src/source/routes/reitit.clj
@@ -74,7 +74,8 @@
             [source.routes.job-stop :as job-stop]
             [source.routes.report :as report]
             [source.routes.approve-feed :as approve-feed]
-            [source.routes.reject-feed :as reject-feed]))
+            [source.routes.reject-feed :as reject-feed]
+            [source.middleware.auth.core :as auth]))
 
 (defn create-app [{:keys [ds js]}]
   (ring/ring-handler
@@ -178,7 +179,8 @@
       ["/:id" (-> (get integration/get)
                   (post integration/post)
                   (delete integration/delete))]
-      ["/:id/refresh" (get integrations/refresh)]
+      ["/:id/refresh" (-> (get integrations/refresh)
+                          (rutil/mw auth/wrap-integration-auth))]
       ["/:id/categories" (-> (get integration-categories/get)
                              (post integration-categories/post))]
       ["/:id/filter/feeds" (get integration-filter-feeds/get)]

--- a/src/source/routes/util.clj
+++ b/src/source/routes/util.clj
@@ -117,3 +117,15 @@
                       :default-values true
                       :options nil})
           :middleware middleware}})
+
+(defn middleware [& middlewares]
+  (let [[route-map mws] (apply parse-route-opts middlewares)
+        middleware (:middleware route-map)
+        mws (-> (or middleware [])
+                (concat mws))]
+    (->> mws
+         (mapv #(if (vector? %) % [%]))
+         (assoc route-map :middleware))))
+
+(defn mw [& middlewares]
+  (apply middleware middlewares))

--- a/src/source/workers/bundles.clj
+++ b/src/source/workers/bundles.clj
@@ -2,7 +2,8 @@
   (:require [source.db.honey :as hon]
             [honey.sql.helpers :as hsql]
             [source.db.util :as db.util]
-            [source.prandom.core :as prandom])
+            [source.prandom.core :as prandom]
+            [pg.core :as pg])
   (:import [java.time LocalDateTime]
            [java.time.format DateTimeFormatter]))
 
@@ -110,6 +111,16 @@
                   :current-index start
                   :next-index (when (and next-index (< next-index total-size)) next-index)}
      :data limited-posts}))
+
+(defn user-owns-bundle? [ds user-id bundle-id]
+  (->
+   (pg/execute
+    ds
+    "SELECT EXISTS(SELECT 1 FROM bundles WHERE id = $1 AND user_id = $2) AS exists"
+    {:params [bundle-id
+              user-id]})
+   (first)
+   (:exists)))
 
 (comment
 


### PR DESCRIPTION
Added endpoint to restart bundle job. This is usable from both admin side and distributor side.

Added middleware for authorization purposes to ensure only admins or a distributor to which the bundle belongs can access it.